### PR TITLE
Combine ofType and ofTypes

### DIFF
--- a/examples/actions.tests.ts
+++ b/examples/actions.tests.ts
@@ -2,7 +2,7 @@ import { equal, deepEqual } from 'assert';
 import { of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { actionCreator, ExtractPayload } from 'rxbeach';
-import { ofTypes, extractPayload, ofType } from 'rxbeach/operators';
+import { extractPayload, ofType } from 'rxbeach/operators';
 
 export default function actionExamples() {
   describe('actions', function() {
@@ -24,7 +24,7 @@ export default function actionExamples() {
     it('can filter actions', async function() {
       const a = primitiveAction(12);
       const r = await of(voidAction(), a, payloadAction({ foo: 123 }))
-        .pipe(ofTypes(primitiveAction.type))
+        .pipe(ofType(primitiveAction))
         .toPromise();
 
       equal(r, a);

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -5,4 +5,5 @@ export {
   UnknownAction,
   ActionCreatorCommon,
   UnknownActionCreator,
+  UnknownActionCreatorWithPayload,
 } from './types';

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,4 +1,5 @@
 import { Action, ActionWithoutPayload } from 'rxbeach';
+import { ActionWithPayload } from 'rxbeach/types/Action';
 
 export type VoidPayload = void;
 
@@ -25,6 +26,17 @@ export type UnknownAction = ActionWithoutPayload & { payload?: any };
 
 export interface ActionCreatorCommon {
   type: string;
+}
+
+/**
+ * Helper type for action creator where only the returned action matters
+ *
+ * This type allows for inferring overlap of the payload type between multiple
+ * action creators with different payloads.
+ */
+export interface UnknownActionCreatorWithPayload<Payload>
+  extends ActionCreatorCommon {
+  (payload?: any): ActionWithPayload<Payload>;
 }
 
 /**

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -1,1 +1,1 @@
-export { ofTypes, ofType, extractPayload, withNamespace } from './operators';
+export { ofType, extractPayload, withNamespace } from './operators';


### PR DESCRIPTION
Previously we could not figure out how to create a strictly typed
version of ofType with variable arity. The type
UnknownActionCreatorWithPayload allows us to infer the overlap of the
payload between multiple action creators, and thus combine these two
functions.

Overloads have been added to allow for usage when there is no overlap
between the payload, but all the action creators have payloads, (in
which case the overlap is `{}`), and for when at least one of the
action creators create void actions.