### PR TITLE
Freeze actions and action creators

### DIFF
--- a/src/actionCreator.tests.ts
+++ b/src/actionCreator.tests.ts
@@ -1,14 +1,40 @@
-import { equal } from 'assert';
+import { equal, deepEqual, AssertionError } from 'assert';
 import { actionCreator } from 'rxbeach';
+import { assertThrows } from 'rxbeach/internal/testUtils';
 
 describe('actionCreator', function() {
   describe('actionCreator', function() {
-    it('Should create action creators and append the type', function() {
-      const myAction = actionCreator<3>('three');
-      const action = myAction(3);
+    type Payload = { num: number };
+    const myAction = actionCreator<Payload>('three');
+    const action = myAction({ num: 3 }) as {
+      type: string;
+      payload: Payload;
+      meta: { namespace?: string };
+    };
 
+    it('Should create action creators and append the type', function() {
       equal(action.type, myAction.type);
-      equal(action.payload, 3);
+      deepEqual(action.payload, { num: 3 });
+    });
+    it('Should protect the type field', function() {
+      assertThrows(TypeError, () => {
+        (myAction as any).type = 'lol';
+      });
+    });
+    it('Should create action objects with protected type', function() {
+      assertThrows(TypeError, () => {
+        action.type = 'mock';
+      });
+    });
+    it('Should create action objects with protected meta', function() {
+      assertThrows(TypeError, () => {
+        action.meta = {};
+      });
+    });
+    it('Should create action objects with protected namespace', function() {
+      assertThrows(TypeError, () => {
+        action.meta.namespace = 'shim';
+      });
     });
   });
 });

--- a/src/actionCreator.ts
+++ b/src/actionCreator.ts
@@ -22,12 +22,13 @@ export function actionCreator<Payload = VoidPayload>(
  * recognize the generic, typed overload of this function.
  */
 export function actionCreator(type: string): UnknownActionCreator {
-  const action = (payload?: any) => ({
-    type,
-    payload,
-    meta: {},
-  });
+  const action = (payload?: any) =>
+    Object.freeze({
+      type,
+      payload,
+      meta: Object.freeze({}),
+    });
   action.type = type;
 
-  return action;
+  return Object.freeze(action);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-// TYPES
 export {
   ActionWithoutPayload,
   ActionWithPayload,

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -1,4 +1,4 @@
-export { mockAction } from './testUtils';
+export { mockAction, assertThrows } from './testUtils';
 export {
   VoidPayload,
   AnyAction,

--- a/src/internal/testUtils.ts
+++ b/src/internal/testUtils.ts
@@ -1,5 +1,6 @@
 import { Action } from 'rxbeach';
 import { VoidPayload } from 'rxbeach/internal';
+import { AssertionError } from 'assert';
 
 export const mockAction = <P = VoidPayload>(
   type: string,
@@ -11,3 +12,15 @@ export const mockAction = <P = VoidPayload>(
     type,
     payload,
   } as Action<P>);
+
+export const assertThrows = (ErrorConstructor: Function, func: () => void) => {
+  try {
+    func();
+  } catch (err) {
+    if (!(err instanceof ErrorConstructor)) {
+      throw new AssertionError({
+        message: 'Expected error to be thrown',
+      });
+    }
+  }
+};

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -25,7 +25,7 @@ export type AnyAction = Action<any>;
 export type UnknownAction = ActionWithoutPayload & { payload?: any };
 
 export interface ActionCreatorCommon {
-  type: string;
+  readonly type: string;
 }
 
 /**

--- a/src/namespace.tests.ts
+++ b/src/namespace.tests.ts
@@ -4,9 +4,33 @@ import {
   ActionDispatcher,
   namespaceActionDispatcher,
 } from 'rxbeach';
-import { mockAction, AnyAction } from 'rxbeach/internal';
+import { mockAction, AnyAction, assertThrows } from 'rxbeach/internal';
+import { _namespaceAction } from './namespace';
 
 describe('namespace', function() {
+  describe('_namespaceAction', function() {
+    const namespaced = _namespaceAction('namespace', mockAction('type')) as {
+      type: string;
+      meta: {
+        namespace: string;
+      };
+    };
+    it('has unwritable type', function() {
+      assertThrows(TypeError, () => {
+        namespaced.type = 'foo';
+      });
+    });
+    it('has unwritable meta', function() {
+      assertThrows(TypeError, () => {
+        namespaced.meta = { namespace: 'bar' };
+      });
+    });
+    it('has unwritable namespace', function() {
+      assertThrows(TypeError, () => {
+        namespaced.meta.namespace = 'baz';
+      });
+    });
+  });
   describe('namespaceActionCreator', function() {
     const type = 'action type';
     const namespace = 'new namespace';

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -1,14 +1,15 @@
 import { ActionCreator, ActionDispatcher } from 'rxbeach';
 import { UnknownAction, VoidPayload } from 'rxbeach/internal';
 
-const _namespaceAction = (namespace: string, action: UnknownAction) => ({
-  type: action.type,
-  payload: action.payload,
-  meta: {
-    ...action.meta,
-    namespace,
-  },
-});
+export const _namespaceAction = (namespace: string, action: UnknownAction) =>
+  Object.freeze({
+    type: action.type,
+    payload: action.payload,
+    meta: Object.freeze({
+      ...action.meta,
+      namespace,
+    }),
+  });
 
 /**
  * Decorate an action creator so the created actions have the given namespace
@@ -32,7 +33,7 @@ export const namespaceActionCreator = <Payload = VoidPayload>(
     _namespaceAction(namespace, actionCreator(payload));
   creator.type = actionCreator.type;
 
-  return creator as ActionCreator<Payload>;
+  return Object.freeze(creator) as ActionCreator<Payload>;
 };
 
 /**

--- a/src/types/Action.ts
+++ b/src/types/Action.ts
@@ -1,16 +1,16 @@
 import { VoidPayload } from 'rxbeach/internal';
 
 type Meta = {
-  namespace?: string;
+  readonly namespace?: string;
 };
 
 export type ActionWithoutPayload = {
-  type: string;
-  meta: Meta;
+  readonly type: string;
+  readonly meta: Meta;
 };
 
 export type ActionWithPayload<Payload> = ActionWithoutPayload & {
-  payload: Payload;
+  readonly payload: Payload;
 };
 
 /**


### PR DESCRIPTION
Makes the `type`, `meta`, `meta.namespace` and `payload` fields of
action objects and action creators protected by TypeScript's `readonly`
keyword and by using `Object.freeze` on the action objects and action
creators when they are created.

This is basically a lite version of #25, which at least moves us closer to fixing #21.