### PR TITLE
Routines

### DIFF
--- a/examples/routines.spec.ts
+++ b/examples/routines.spec.ts
@@ -14,7 +14,7 @@ const pongs: 'pong'[] = [];
 
 const logPongs = routine(
   ofType(pong),
-  tap(action => pongs.push('pong')) // Simulates console.log
+  tap(() => pongs.push('pong')) // Simulates console.log
 );
 const pongPings = routine(
   ofType(ping),

--- a/examples/routines.spec.ts
+++ b/examples/routines.spec.ts
@@ -1,0 +1,36 @@
+import test from 'ava';
+import { of } from 'rxjs';
+import { tap, map } from 'rxjs/operators';
+import { actionCreator } from 'rxbeach';
+import { AnyAction } from 'rxbeach/internal';
+import { ofType } from 'rxbeach/operators';
+import { routine, collectRoutines } from 'rxbeach/routines';
+
+const ping = actionCreator('[game] ping');
+const pong = actionCreator('[game] pong');
+
+const dispatched: AnyAction[] = [];
+const pongs: 'pong'[] = [];
+
+const logPongs = routine(
+  ofType(pong),
+  tap(action => pongs.push('pong')) // Simulates console.log
+);
+const pongPings = routine(
+  ofType(ping),
+  map(() => pong()),
+  tap(dispatched.push.bind(dispatched)) // Simulates tap(dispatchAction)
+);
+
+const routines = collectRoutines(logPongs, pongPings);
+
+test('works', async t => {
+  await of(ping(), pong())
+    .pipe(routines)
+    .toPromise();
+
+  t.deepEqual(dispatched, [
+    { type: '[game] pong', meta: {}, payload: undefined },
+  ]);
+  t.deepEqual(pongs, ['pong']);
+});

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^0.1.3",
+    "@types/sinon": "^7.5.0",
     "@typescript-eslint/eslint-plugin": "2.2.0",
     "@typescript-eslint/parser": "2.2.0",
     "ava": "^2.4.0",
@@ -39,6 +40,7 @@
     "prettier": "1.18.2",
     "rimraf": "3.0.0",
     "rxjs-marbles": "5.0.3",
+    "sinon": "^7.5.0",
     "source-map-support": "^0.5.16",
     "tap-xunit": "2.4.1",
     "ts-node": "^8.4.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "scripts": {
     "test": "yarn nyc ava",
+    "watch": "yarn ava --watch",
     "check-types": "tsc -p tsconfig.json",
     "lint": "eslint --ext .ts src examples",
     "build": "rimraf dist && yarn tsc -p tsconfig-build.json",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,3 +17,10 @@ export {
 export { actionCreator } from './actionCreator';
 
 export { namespaceActionCreator, namespaceActionDispatcher } from './namespace';
+
+export {
+  Routine,
+  subscribeRoutine,
+  routine,
+  collectRoutines,
+} from './routines';

--- a/src/internal/defaultErrorSubject.spec.ts
+++ b/src/internal/defaultErrorSubject.spec.ts
@@ -1,0 +1,15 @@
+import untypedTest from 'ava';
+import {
+  defaultErrorSubject,
+  stubRethrowErrorGlobally,
+} from 'rxbeach/internal';
+
+const test = stubRethrowErrorGlobally(untypedTest);
+
+test('defaultErrorSubject rethrows errors globally', t => {
+  const error = new Error('Hello errors');
+  defaultErrorSubject.next(error);
+
+  t.context.rethrowErrorGlobally.calledOnceWithExactly(error);
+  t.pass();
+});

--- a/src/internal/defaultErrorSubject.ts
+++ b/src/internal/defaultErrorSubject.ts
@@ -1,0 +1,15 @@
+import { Subject } from 'rxjs';
+import { rethrowErrorGlobally } from 'rxbeach/internal';
+
+/**
+ * The default error subject is where errors that RxBeach has silenced will go
+ * if no other error subjects are specified.
+ *
+ * This subject is by default subscribed so that all the erros that it emits are
+ * rethrown globally, with `rethrowErrorGlobally`
+ *
+ * @see rethrowErrorGlobally
+ */
+export const defaultErrorSubject = new Subject<any>();
+
+defaultErrorSubject.subscribe(error => rethrowErrorGlobally(error));

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -1,4 +1,4 @@
-export { mockAction } from './testUtils';
+export { mockAction, stubRethrowErrorGlobally } from './testUtils';
 export {
   VoidPayload,
   AnyAction,
@@ -9,3 +9,5 @@ export {
 } from './types';
 export { RoutineFunc } from './routineFunc';
 export { coldMergeOperators } from '../operators/mergeOperators';
+export { defaultErrorSubject } from './defaultErrorSubject';
+export { rethrowErrorGlobally } from './rethrowErrorGlobally';

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -7,3 +7,5 @@ export {
   UnknownActionCreator,
   UnknownActionCreatorWithPayload,
 } from './types';
+export { RoutineFunc } from './routineFunc';
+export { coldMergeOperators } from '../operators/mergeOperators';

--- a/src/internal/rethrowErrorGlobally.spec.ts
+++ b/src/internal/rethrowErrorGlobally.spec.ts
@@ -1,0 +1,19 @@
+import untypedTest, { TestInterface } from 'ava';
+import sinon from 'sinon';
+import { rethrowErrorGlobally } from 'rxbeach/internal';
+
+const test = untypedTest as TestInterface<{ clock: sinon.SinonFakeTimers }>;
+
+test.before(t => {
+  t.context.clock = sinon.useFakeTimers();
+});
+test.beforeEach(t => t.context.clock.reset());
+test.after(t => t.context.clock.restore());
+
+test('rethrows error globally', t => {
+  const message = 'Hello errors!';
+
+  rethrowErrorGlobally(new Error(message));
+
+  t.throws(() => t.context.clock.tick(1), Error, message);
+});

--- a/src/internal/rethrowErrorGlobally.ts
+++ b/src/internal/rethrowErrorGlobally.ts
@@ -1,0 +1,12 @@
+/**
+ * Throws an error in a setTimout
+ *
+ * The error will become an uncaught error, as it's thrown on the main loop.
+ * In the browser, these errors can be caught with `window.onerror`.
+ *
+ * @param error The error to rethrow
+ */
+export const rethrowErrorGlobally = (error: any) =>
+  setTimeout(() => {
+    throw error;
+  });

--- a/src/internal/routineFunc.ts
+++ b/src/internal/routineFunc.ts
@@ -1,0 +1,105 @@
+import { OperatorFunction } from 'rxjs';
+import { Routine } from 'rxbeach/routines';
+
+export interface RoutineFunc {
+  /**
+   * See collectRoutines for documentation
+   */
+  <A>(fn1: Routine<A>): Routine<A>;
+  /**
+   * See collectRoutines for documentation
+   */
+  <A, B>(fn1: Routine<A>, fn2: OperatorFunction<A, B>): Routine<B>;
+  /**
+   * See collectRoutines for documentation
+   */
+  <A, B, C>(
+    fn1: Routine<A>,
+    fn2: OperatorFunction<A, B>,
+    fn3: OperatorFunction<B, C>
+  ): Routine<C>;
+  /**
+   * See collectRoutines for documentation
+   */
+  <A, B, C, D>(
+    fn1: Routine<A>,
+    fn2: OperatorFunction<A, B>,
+    fn3: OperatorFunction<B, C>,
+    fn4: OperatorFunction<C, D>
+  ): Routine<D>;
+  /**
+   * See collectRoutines for documentation
+   */
+  <A, B, C, D, E>(
+    fn1: Routine<A>,
+    fn2: OperatorFunction<A, B>,
+    fn3: OperatorFunction<B, C>,
+    fn4: OperatorFunction<C, D>,
+    fn5: OperatorFunction<D, E>
+  ): Routine<E>;
+  /**
+   * See collectRoutines for documentation
+   */
+  <A, B, C, D, E, F>(
+    fn1: Routine<A>,
+    fn2: OperatorFunction<A, B>,
+    fn3: OperatorFunction<B, C>,
+    fn4: OperatorFunction<C, D>,
+    fn5: OperatorFunction<D, E>,
+    fn6: OperatorFunction<E, F>
+  ): Routine<F>;
+  /**
+   * See collectRoutines for documentation
+   */
+  <A, B, C, D, E, F, G>(
+    fn1: Routine<A>,
+    fn2: OperatorFunction<A, B>,
+    fn3: OperatorFunction<B, C>,
+    fn4: OperatorFunction<C, D>,
+    fn5: OperatorFunction<D, E>,
+    fn6: OperatorFunction<E, F>,
+    fn7: OperatorFunction<F, G>
+  ): Routine<G>;
+  /**
+   * See collectRoutines for documentation
+   */
+  <A, B, C, D, E, F, G, H>(
+    fn1: Routine<A>,
+    fn2: OperatorFunction<A, B>,
+    fn3: OperatorFunction<B, C>,
+    fn4: OperatorFunction<C, D>,
+    fn5: OperatorFunction<D, E>,
+    fn6: OperatorFunction<E, F>,
+    fn7: OperatorFunction<F, G>,
+    fn8: OperatorFunction<G, H>
+  ): Routine<H>;
+  /**
+   * See collectRoutines for documentation
+   */
+  <A, B, C, D, E, F, G, H, I>(
+    fn1: Routine<A>,
+    fn2: OperatorFunction<A, B>,
+    fn3: OperatorFunction<B, C>,
+    fn4: OperatorFunction<C, D>,
+    fn5: OperatorFunction<D, E>,
+    fn6: OperatorFunction<E, F>,
+    fn7: OperatorFunction<F, G>,
+    fn8: OperatorFunction<G, H>,
+    fn9: OperatorFunction<H, I>
+  ): Routine<I>;
+  /**
+   * See collectRoutines for documentation
+   */
+  <A, B, C, D, E, F, G, H, I>(
+    fn1: Routine<A>,
+    fn2: OperatorFunction<A, B>,
+    fn3: OperatorFunction<B, C>,
+    fn4: OperatorFunction<C, D>,
+    fn5: OperatorFunction<D, E>,
+    fn6: OperatorFunction<E, F>,
+    fn7: OperatorFunction<F, G>,
+    fn8: OperatorFunction<G, H>,
+    fn9: OperatorFunction<H, I>,
+    ...fns: OperatorFunction<any, any>[]
+  ): Routine<{}>;
+}

--- a/src/internal/testUtils.ts
+++ b/src/internal/testUtils.ts
@@ -1,5 +1,8 @@
 import { Action } from 'rxbeach';
 import { VoidPayload } from 'rxbeach/internal';
+import * as internals from 'rxbeach/internal';
+import sinon, { SinonStub } from 'sinon';
+import { TestInterface } from 'ava';
 
 export const mockAction = <P = VoidPayload>(
   type: string,
@@ -11,3 +14,21 @@ export const mockAction = <P = VoidPayload>(
     type,
     payload,
   } as Action<P>);
+
+export type TestContextRethrowErrorGlobally = {
+  rethrowErrorGlobally: SinonStub<[any], number>;
+};
+
+export const stubRethrowErrorGlobally = (untypedTest: TestInterface) => {
+  const test = untypedTest as TestInterface<TestContextRethrowErrorGlobally>;
+  test.before(t => {
+    t.context.rethrowErrorGlobally = sinon.stub(
+      internals,
+      'rethrowErrorGlobally'
+    );
+  });
+  test.after(t => t.context.rethrowErrorGlobally.restore());
+  test.beforeEach(t => t.context.rethrowErrorGlobally.reset());
+
+  return test;
+};

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -1,1 +1,2 @@
 export { ofType, extractPayload, withNamespace } from './operators';
+export { mergeOperators } from './mergeOperators';

--- a/src/operators/mergeOperators.spec.ts
+++ b/src/operators/mergeOperators.spec.ts
@@ -1,0 +1,32 @@
+import test from 'ava';
+import { map } from 'rxjs/operators';
+import { marbles } from 'rxjs-marbles/ava';
+import { mergeOperators } from 'rxbeach/operators';
+import { coldMergeOperators } from './mergeOperators';
+
+const double = map<number, number>(n => n * 2);
+const halve = map<number, number>(n => n / 2);
+
+const numbers = { 1: 1, 2: 2, 4: 4, 8: 8 };
+const source = '  2---4';
+const expected = '(41)(82)';
+const sub = '     ^';
+
+test(
+  'coldMergeOperators should emit from all and subscribe for all operators',
+  marbles(m => {
+    const source$ = m.cold(source, numbers);
+    const actual = source$.pipe(coldMergeOperators(double, halve));
+    m.expect(actual).toBeObservable(expected, numbers);
+    m.expect(source$).toHaveSubscriptions([sub, sub]);
+  })
+);
+test(
+  'mergeOperators should emit from all operators, but only subscribe source once',
+  marbles(m => {
+    const source$ = m.cold(source, numbers);
+    const actual = source$.pipe(mergeOperators(double, halve));
+    m.expect(actual).toBeObservable(expected, numbers);
+    m.expect(source$).toHaveSubscriptions([sub]);
+  })
+);

--- a/src/operators/mergeOperators.spec.ts
+++ b/src/operators/mergeOperators.spec.ts
@@ -2,7 +2,7 @@ import test from 'ava';
 import { map } from 'rxjs/operators';
 import { marbles } from 'rxjs-marbles/ava';
 import { mergeOperators } from 'rxbeach/operators';
-import { coldMergeOperators } from './mergeOperators';
+import { coldMergeOperators } from 'rxbeach/internal';
 
 const double = map<number, number>(n => n * 2);
 const halve = map<number, number>(n => n / 2);

--- a/src/operators/mergeOperators.ts
+++ b/src/operators/mergeOperators.ts
@@ -1,0 +1,44 @@
+import { OperatorFunction, merge, pipe } from 'rxjs';
+import { share } from 'rxjs/operators';
+
+/**
+ * Runs operators in parallel and merges their results
+ *
+ * For each operator, the returned observable is subscribed to a pipe from the
+ * source observable with the operator. This makes it a bit like the `flatMap`
+ * operator and the `merge` function, but on an operator level instead of value
+ * or observable level.
+ *
+ * NB: Each operator will create a "copy" of the stream, so any operators
+ *     before the `coldMergeOperators` operator, will be executed for each
+ *     operator passed to `coldMergeOperators`. Because of this, you might want
+ *     to use the `mergeOperators` operator, which includes a `share` operator
+ *     to make the upstream hot.
+ *
+ * @param operators Operators to run in parallell and merge the results of
+ */
+export const coldMergeOperators = <T, R>(
+  ...operators: OperatorFunction<T, R>[]
+): OperatorFunction<T, R> => source =>
+  merge(...operators.map(operator => source.pipe(operator)));
+
+/**
+ * Runs operators in parallel and merges their results
+ *
+ * For each operator, the returned observable is subscribed to a pipe from the
+ * source observable with the operator. This makes it a bit like the `flatMap`
+ * operator and the merge function, but on an operator level instead of value
+ * or observable level.
+ *
+ * This operator includes the `share` operator on the parent stream, to prevent
+ * operators that are attached before this one from running multiple times.
+ *
+ * @param operators Operators to run in parallell and merge the results of
+ */
+export const mergeOperators = <T, R>(
+  ...operators: OperatorFunction<T, R>[]
+): OperatorFunction<T, R> =>
+  pipe(
+    share(),
+    coldMergeOperators(...operators)
+  );

--- a/src/routines.spec.ts
+++ b/src/routines.spec.ts
@@ -1,0 +1,113 @@
+import test from 'ava';
+import { Subject } from 'rxjs';
+import { map, filter } from 'rxjs/operators';
+import { marbles } from 'rxjs-marbles/ava';
+import {
+  ActionWithPayload,
+  Routine,
+  subscribeRoutine,
+  routine,
+  collectRoutines,
+} from 'rxbeach';
+import { mockAction } from 'rxbeach/internal';
+import { extractPayload } from 'rxbeach/operators';
+
+const actions = {
+  a: mockAction('alpha', undefined, { letter: 'A' }),
+  b: mockAction('bravo', undefined, { letter: 'B' }),
+  c: mockAction('charlie', undefined, { letter: 'C' }),
+  e: mockAction('error'),
+};
+const letters = {
+  A: 'A',
+  B: 'B',
+  C: 'C',
+};
+const lengths = {
+  ...letters,
+  '5': 5,
+  '7': 7,
+};
+const errors = {
+  e: 'error',
+};
+const actionMarbles1 = ' -a----b----c---';
+const letterMarbles = '  -A----B----C---';
+const combinedMarbles = '-(A5)-(B5)-(C7)';
+const actionMarbles2 = ' -a----e----a---';
+const errorMarbles = '   ------e';
+const errorSub1 = '      ^-----!';
+const errorSub2 = '      ------^--------';
+
+const errorRoutine: Routine<string> = map(a => {
+  if (a.type === 'error') throw 'error';
+  return 'passed';
+});
+const lettersRoutine = routine(
+  filter(
+    (action: any): action is ActionWithPayload<{ letter: string }> =>
+      action.payload !== undefined
+  ),
+  extractPayload(),
+  map(({ letter }) => letter)
+);
+const lengthRoutine = routine(map(({ type }) => type.length));
+
+test(
+  'routine pipes multiple operator functions',
+  marbles(m => {
+    const action$ = m.hot(actionMarbles1, actions);
+    const expected$ = m.hot(letterMarbles, letters);
+
+    const actual$ = action$.pipe(lettersRoutine);
+
+    m.expect(actual$).toBeObservable(expected$);
+  })
+);
+
+test(
+  'collectRoutines runs all routines',
+  marbles(m => {
+    const action$ = m.hot(actionMarbles1, actions);
+    const expected$ = m.hot(combinedMarbles, lengths);
+
+    const actual$ = action$.pipe(
+      collectRoutines(lettersRoutine, lengthRoutine)
+    );
+
+    m.expect(actual$).toBeObservable(expected$);
+  })
+);
+
+test(
+  'subscribeRoutine subscribes action$',
+  marbles(m => {
+    const action$ = m.hot(actionMarbles1, actions);
+    subscribeRoutine(action$, lettersRoutine);
+
+    m.expect(action$).toHaveSubscriptions(['^']);
+  })
+);
+
+test(
+  'subscribeRoutine resubscribes on errors',
+  marbles((m, t) => {
+    const action$ = m.hot(actionMarbles2, actions);
+
+    subscribeRoutine(action$, errorRoutine);
+
+    m.expect(action$).toHaveSubscriptions([errorSub1, errorSub2]);
+  })
+);
+
+test(
+  'subscribeRoutine emits errors to error subject',
+  marbles((m, t) => {
+    const action$ = m.hot(actionMarbles2, actions);
+    const error$ = new Subject<any>();
+
+    subscribeRoutine(action$, errorRoutine, error$);
+
+    m.expect(error$).toBeObservable(errorMarbles, errors);
+  })
+);

--- a/src/routines.spec.ts
+++ b/src/routines.spec.ts
@@ -1,4 +1,4 @@
-import test from 'ava';
+import untypedTest from 'ava';
 import { Subject } from 'rxjs';
 import { map, filter } from 'rxjs/operators';
 import { marbles } from 'rxjs-marbles/ava';
@@ -9,8 +9,10 @@ import {
   routine,
   collectRoutines,
 } from 'rxbeach';
-import { mockAction } from 'rxbeach/internal';
+import { mockAction, stubRethrowErrorGlobally } from 'rxbeach/internal';
 import { extractPayload } from 'rxbeach/operators';
+
+const test = stubRethrowErrorGlobally(untypedTest);
 
 const actions = {
   a: mockAction('alpha', undefined, { letter: 'A' }),
@@ -91,7 +93,7 @@ test(
 
 test(
   'subscribeRoutine resubscribes on errors',
-  marbles((m, t) => {
+  marbles(m => {
     const action$ = m.hot(actionMarbles2, actions);
 
     subscribeRoutine(action$, errorRoutine);
@@ -102,7 +104,7 @@ test(
 
 test(
   'subscribeRoutine emits errors to error subject',
-  marbles((m, t) => {
+  marbles(m => {
     const action$ = m.hot(actionMarbles2, actions);
     const error$ = new Subject<any>();
 

--- a/src/routines.ts
+++ b/src/routines.ts
@@ -1,0 +1,61 @@
+import { OperatorFunction, pipe, Subject } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { ActionStream } from 'rxbeach';
+import { AnyAction, RoutineFunc } from 'rxbeach/internal';
+import { mergeOperators } from 'rxbeach/operators';
+
+export type Routine<T> = OperatorFunction<AnyAction, T>;
+
+/**
+ * See collectRoutines for documentation
+ */
+export const routine: RoutineFunc = (
+  ...args: OperatorFunction<any, any>[]
+): Routine<any> => pipe(...(args as [OperatorFunction<any, any>]));
+
+/**
+ * Collect multiple routines to one
+ *
+ * A routine is simply a stream operator that will recieve actions, and is
+ * supposed to perform side effects. This function uses the composite pattern,
+ * so multiple routines can be collected into one routine.
+ *
+ * Routines are subscribed by passing them to a `subscribeRoutine` call.
+ *
+ * @see subscribeRoutine
+ * @param routines The routines to collect
+ * @returns A routine that calls the provided routines
+ */
+export const collectRoutines = (
+  ...routines: Routine<unknown>[]
+): Routine<unknown> => mergeOperators(...routines);
+
+/**
+ * Subscribe a routine to an action stream
+ *
+ * The subscription will silence errors, meaning the errors will be emitted on
+ * the optional error subject, but the routine will not be unsubscribed. This
+ * makes sure the whole routine doesn't crash from a single faulty action. Make
+ * sure that the action stream is a hot stream, so the routine will not recieve
+ * the same error indefinetly.
+ *
+ * @param action$ The action stream to subscribe the routine to
+ * @param routine The routine to subscribe
+ * @param errorSubject An optional Subject that will recieve errors form the
+ *                     routine
+ * @returns A Subscription object
+ */
+export const subscribeRoutine = (
+  action$: ActionStream,
+  routine: Routine<unknown>,
+  errorSubject?: Subject<any>
+) =>
+  action$
+    .pipe(
+      routine,
+      catchError((err, stream) => {
+        if (errorSubject) errorSubject.next(err);
+        return stream;
+      })
+    )
+    .subscribe();

--- a/src/routines.ts
+++ b/src/routines.ts
@@ -1,7 +1,7 @@
 import { OperatorFunction, pipe, Subject } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { ActionStream } from 'rxbeach';
-import { AnyAction, RoutineFunc } from 'rxbeach/internal';
+import { AnyAction, RoutineFunc, defaultErrorSubject } from 'rxbeach/internal';
 import { mergeOperators } from 'rxbeach/operators';
 
 export type Routine<T> = OperatorFunction<AnyAction, T>;
@@ -33,28 +33,34 @@ export const collectRoutines = (
 /**
  * Subscribe a routine to an action stream
  *
- * The subscription will silence errors, meaning the errors will be emitted on
- * the optional error subject, but the routine will not be unsubscribed. This
- * makes sure the whole routine doesn't crash from a single faulty action. Make
- * sure that the action stream is a hot stream, so the routine will not recieve
- * the same error indefinetly.
+ * Errors will not cause the routine to be unsubscribed from the action stream.
+ * We assume all errors stem from faulty action objects, so we allow ourselves
+ * to continue the routine on errors. It is therefore important that the action
+ * stream is "hot", so the same action object is not re-emitted right away to
+ * the routine.
+ *
+ * If a routine throws an error, it will be nexted on the error subject. If the
+ * error subject is not explicitly set, it will default to
+ * `defaultErrorSubject`, which will rethrow the errors globally, as uncaught
+ * exceptions.
  *
  * @param action$ The action stream to subscribe the routine to
  * @param routine The routine to subscribe
  * @param errorSubject An optional Subject that will recieve errors form the
  *                     routine
  * @returns A Subscription object
+ * @see defaultErrorSubject
  */
 export const subscribeRoutine = (
   action$: ActionStream,
   routine: Routine<unknown>,
-  errorSubject?: Subject<any>
+  errorSubject: Subject<any> = defaultErrorSubject
 ) =>
   action$
     .pipe(
       routine,
       catchError((err, stream) => {
-        if (errorSubject) errorSubject.next(err);
+        errorSubject.next(err);
         return stream;
       })
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -383,6 +383,35 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.4.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.6.0.tgz#ec7670432ae9c8eb710400d112c201a362d83393"
+  integrity sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/formatio@^3.2.1":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.2.2.tgz#771c60dfa75ea7f2d68e3b94c7e888a78781372c"
+  integrity sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==
+  dependencies:
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^3.1.0"
+
+"@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.3.3":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.3.tgz#46682efd9967b259b81136b9f120fd54585feb4a"
+  integrity sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==
+  dependencies:
+    "@sinonjs/commons" "^1.3.0"
+    array-from "^2.1.1"
+    lodash "^4.17.15"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
@@ -433,6 +462,11 @@
   version "12.12.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.5.tgz#66103d2eddc543d44a04394abb7be52506d7f290"
   integrity sha512-KEjODidV4XYUlJBF3XdjSH5FWoMCtO0utnhtdLf1AgeuZLOrRbvmU/gaRCVg7ZaQDjVf3l84egiY0mRNe5xE4A==
+
+"@types/sinon@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-7.5.0.tgz#f5a10c27175465a0b001b68d8b9f761582967cc6"
+  integrity sha512-NyzhuSBy97B/zE58cDw4NyGvByQbAHNP9069KVSgnXt/sc0T6MFRh0InKAeBVHJWdSXG1S3+PxgVIgKo9mTHbw==
 
 "@types/stacktrace-js@^0.0.32":
   version "0.0.32"
@@ -583,6 +617,11 @@ array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
   integrity sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=
+
+array-from@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
+  integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
 
 array-includes@^3.0.3:
   version "3.0.3"
@@ -1290,6 +1329,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+diff@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
 diff@^4.0.1:
   version "4.0.1"
@@ -2330,6 +2374,11 @@ is-yarn-global@^0.3.0:
   resolved "https://registry.yarnpkg.com/is-yarn-global/-/is-yarn-global-0.3.0.tgz#d502d3382590ea3004893746754c89139973e232"
   integrity sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -2489,6 +2538,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+just-extend@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
+  integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
+
 keyv@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
@@ -2611,6 +2665,11 @@ log-symbols@^2.2.0:
   integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
   dependencies:
     chalk "^2.0.1"
+
+lolex@^4.1.0, lolex@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-4.2.0.tgz#ddbd7f6213ca1ea5826901ab1222b65d714b3cd7"
+  integrity sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -2842,6 +2901,17 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+nise@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.5.2.tgz#b6d29af10e48b321b307e10e065199338eeb2652"
+  integrity sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==
+  dependencies:
+    "@sinonjs/formatio" "^3.2.1"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    lolex "^4.1.0"
+    path-to-regexp "^1.7.0"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.5.0"
@@ -3163,6 +3233,13 @@ path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -3693,6 +3770,19 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
+sinon@^7.5.0:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.5.0.tgz#e9488ea466070ea908fd44a3d6478fd4923c67ec"
+  integrity sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==
+  dependencies:
+    "@sinonjs/commons" "^1.4.0"
+    "@sinonjs/formatio" "^3.2.1"
+    "@sinonjs/samsam" "^3.3.3"
+    diff "^3.5.0"
+    lolex "^4.2.0"
+    nise "^1.5.2"
+    supports-color "^5.5.0"
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -3920,7 +4010,7 @@ supertap@^1.0.0:
     serialize-error "^2.1.0"
     strip-ansi "^4.0.0"
 
-supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -4117,6 +4207,11 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.3.0:
   version "0.3.1"


### PR DESCRIPTION
This suggestion for routines uses the same approach as the `subscribeAndGuard` based routines in Ardoq front. 

A routine is simply an operator function that takes in actions. `collectRoutines` is a composable functino that "bundles" multiple routines as a single operator function.

For hooking routines into the `action$`, something like `subscribeAndGuard(action$.pipe(reducers))` would be needed, but I plan to add a util around that, with well thought out error handling and such.

One effect of this approach is that the users of the routine would be forced to write in a reactive style - in contrast with `RoutineMap` where the routines can look like normal functions.

TODO:
 - [x] More tests
 - [x] `registerRoutines`
 - [x] Docs for `collectRoutine`
 - [x] Fix the exports through `index.ts`