### PR TITLE
improve grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > Chill with streams at the RxBeach
 
 RxBeach is a toolbox for creating applications that uses streams to manage
-state. It is in the **very early ages** of implementation, and the API will
+state. It is in the **very early stages** of implementation, and the API will
 change continuously.
 
 


### PR DESCRIPTION
"early ages of x" would refer to an epoch, like "early ages of mankind"

"early stages of x" is a more common expression which fits this context better.

https://www.google.com/search?q=%22early+ages+of%22
https://www.google.com/search?q=%22early+stages+of%22