### PR TITLE
Remove AnyAction

### DIFF
--- a/examples/globalActions.ts
+++ b/examples/globalActions.ts
@@ -1,8 +1,9 @@
 import { Subject } from 'rxjs';
-import { Action, ActionDispatcher, ActionStream } from 'rxbeach';
+import { ActionDispatcher, ActionStream } from 'rxbeach';
 import { tag } from 'rxjs-spy/operators';
+import { UnknownAction } from 'rxbeach/internal';
 
-const actionSubject$ = new Subject<Action<any>>();
+const actionSubject$ = new Subject<UnknownAction>();
 
 export const action$: ActionStream = actionSubject$.pipe(tag('action$'));
 

--- a/examples/namespacingActionCreators.spec.ts
+++ b/examples/namespacingActionCreators.spec.ts
@@ -3,7 +3,7 @@ import { of } from 'rxjs';
 import { reduce } from 'rxjs/operators';
 import { actionCreator, namespaceActionCreator } from 'rxbeach';
 import { withNamespace } from 'rxbeach/operators';
-import { AnyAction } from 'rxbeach/internal';
+import { UnknownAction } from 'rxbeach/internal';
 
 const testAction = actionCreator<number>('[test] primitive action');
 const namespaceA = 'A';
@@ -14,8 +14,8 @@ const testActionB = namespaceActionCreator(namespaceB, testAction);
 const actionObjectA = testActionA(1);
 const actionObjectB = testActionB(2);
 
-let lastActionNamespaceA: AnyAction | undefined;
-let lastActionNamespaceB: AnyAction | undefined;
+let lastActionNamespaceA: UnknownAction | undefined;
+let lastActionNamespaceB: UnknownAction | undefined;
 let sumAllNamespaces: number | undefined;
 
 test.before(async function() {

--- a/examples/namespacingActionDispatchers.spec.ts
+++ b/examples/namespacingActionDispatchers.spec.ts
@@ -3,17 +3,17 @@ import { Subject } from 'rxjs';
 import { reduce } from 'rxjs/operators';
 import { actionCreator, namespaceActionDispatcher } from 'rxbeach';
 import { withNamespace } from 'rxbeach/operators';
-import { AnyAction, mockAction } from 'rxbeach/internal';
+import { mockAction, UnknownAction } from 'rxbeach/internal';
 const testAction = actionCreator<number>('[test] primitive action');
 const namespaceA = 'A';
 const namespaceB = 'B';
 
-let lastActionNamespaceA: AnyAction | undefined;
-let lastActionNamespaceB: AnyAction | undefined;
+let lastActionNamespaceA: UnknownAction | undefined;
+let lastActionNamespaceB: UnknownAction | undefined;
 let sumAllNamespaces: number | undefined;
 
 test.before(async function() {
-  const action$ = new Subject<AnyAction>();
+  const action$ = new Subject<UnknownAction>();
   const dispatchAction = action$.next.bind(action$);
 
   const dispatchA = namespaceActionDispatcher(namespaceA, dispatchAction);

--- a/examples/routines.spec.ts
+++ b/examples/routines.spec.ts
@@ -2,14 +2,14 @@ import test from 'ava';
 import { of } from 'rxjs';
 import { tap, map } from 'rxjs/operators';
 import { actionCreator } from 'rxbeach';
-import { AnyAction } from 'rxbeach/internal';
+import { UnknownAction } from 'rxbeach/internal';
 import { ofType } from 'rxbeach/operators';
 import { routine, collectRoutines } from 'rxbeach/routines';
 
 const ping = actionCreator('[game] ping');
 const pong = actionCreator('[game] pong');
 
-const dispatched: AnyAction[] = [];
+const dispatched: UnknownAction[] = [];
 const pongs: 'pong'[] = [];
 
 const logPongs = routine(

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -1,7 +1,6 @@
 export { mockAction, stubRethrowErrorGlobally } from './testUtils';
 export {
   VoidPayload,
-  AnyAction,
   UnknownAction,
   ActionCreatorCommon,
   UnknownActionCreator,

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,4 +1,4 @@
-import { Action, ActionWithoutPayload } from 'rxbeach';
+import { ActionWithoutPayload } from 'rxbeach';
 import { ActionWithPayload } from 'rxbeach/types/Action';
 
 export type VoidPayload = void;
@@ -6,23 +6,11 @@ export type VoidPayload = void;
 /**
  * Helper type for any action
  *
- * TypeScript will interpret this to a union type of `ActionWithPayload<any>`
- * and `ActionWithoutPayload`.
- *
- * Prefer this type when you need to handle actions that you don't know anything
+ * This type has payload as an optional, unknown field, and is useful if you
+ * want to extract a possible `payload` from an action you don't know anything
  * about.
  */
-export type AnyAction = Action<any>;
-
-/**
- * Helper type for any action, where `AnyAction` doesn't suffice
- *
- * This type has payload as an optional field, and is useful if you want to
- * extract a possible `payload` from an action you don't know anything about.
- *
- * `AnyAction` is assignable to `UnknownAction` and vice versa.
- */
-export type UnknownAction = ActionWithoutPayload & { payload?: any };
+export type UnknownAction = ActionWithoutPayload & { payload?: unknown };
 
 export interface ActionCreatorCommon {
   readonly type: string;

--- a/src/namespace.spec.ts
+++ b/src/namespace.spec.ts
@@ -4,7 +4,7 @@ import {
   ActionDispatcher,
   namespaceActionDispatcher,
 } from 'rxbeach';
-import { mockAction, AnyAction } from 'rxbeach/internal';
+import { mockAction, UnknownAction } from 'rxbeach/internal';
 import { _namespaceAction } from 'rxbeach/namespace';
 
 const namespaced = _namespaceAction('namespace', mockAction('type')) as {
@@ -48,7 +48,7 @@ test('namespaceActionCreator should create actions with namespace', t => {
 });
 
 test('namespaceActionDispatcher should invoke the parent dispatcher with namespaced actions', t => {
-  let dispatchedAction: AnyAction | undefined;
+  let dispatchedAction: UnknownAction | undefined;
   const parentDispatcher: ActionDispatcher = action =>
     (dispatchedAction = action);
 

--- a/src/operators/operators.ts
+++ b/src/operators/operators.ts
@@ -2,7 +2,6 @@ import { OperatorFunction, MonoTypeOperatorFunction } from 'rxjs';
 import { map, filter } from 'rxjs/operators';
 import { ActionWithPayload, Action } from 'rxbeach';
 import {
-  AnyAction,
   UnknownActionCreatorWithPayload,
   UnknownActionCreator,
   UnknownAction,
@@ -27,7 +26,7 @@ interface OfType {
    */
   <Payload>(
     ...targetTypes: UnknownActionCreatorWithPayload<Payload>[]
-  ): OperatorFunction<AnyAction, Action<Payload>>;
+  ): OperatorFunction<UnknownAction, Action<Payload>>;
 
   /**
    * Stream operator to filter specific actions that have non-overlapping payload
@@ -48,7 +47,7 @@ interface OfType {
    * @param targetTypes The types to filter for
    */
   (...targetTypes: UnknownActionCreatorWithPayload<{}>[]): OperatorFunction<
-    AnyAction,
+    UnknownAction,
     ActionWithPayload<{}>
   >;
 
@@ -67,16 +66,16 @@ interface OfType {
    * @param targetTypes The types to filter for
    */
   (...targetTypes: UnknownActionCreator[]): OperatorFunction<
-    AnyAction,
+    UnknownAction,
     ActionWithoutPayload
   >;
 }
 export const ofType: OfType = ((
   ...targetTypes: UnknownActionCreator[]
-): OperatorFunction<AnyAction, UnknownAction> => {
+): OperatorFunction<UnknownAction, UnknownAction> => {
   const types = new Set(targetTypes.map(({ type }) => type));
 
-  return filter((action: AnyAction) => types.has(action.type));
+  return filter((action: UnknownAction) => types.has(action.type));
 }) as any; // Implementation is untyped
 
 /**
@@ -98,5 +97,5 @@ export const extractPayload = <Payload>(): OperatorFunction<
  */
 export const withNamespace = (
   targetNamespace: string
-): MonoTypeOperatorFunction<Action<any>> =>
+): MonoTypeOperatorFunction<UnknownAction> =>
   filter(({ meta: { namespace } }) => namespace === targetNamespace);

--- a/src/routines.ts
+++ b/src/routines.ts
@@ -1,10 +1,14 @@
 import { OperatorFunction, pipe, Subject } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { ActionStream } from 'rxbeach';
-import { AnyAction, RoutineFunc, defaultErrorSubject } from 'rxbeach/internal';
+import {
+  RoutineFunc,
+  defaultErrorSubject,
+  UnknownAction,
+} from 'rxbeach/internal';
 import { mergeOperators } from 'rxbeach/operators';
 
-export type Routine<T> = OperatorFunction<AnyAction, T>;
+export type Routine<T> = OperatorFunction<UnknownAction, T>;
 
 /**
  * See collectRoutines for documentation

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -1,8 +1,8 @@
 import { Observable } from 'rxjs';
 import { ActionCreatorWithPayload } from 'rxbeach';
-import { AnyAction, UnknownAction } from 'rxbeach/internal';
+import { UnknownAction } from 'rxbeach/internal';
 
-export type ActionStream = Observable<AnyAction>;
+export type ActionStream = Observable<UnknownAction>;
 
 export type ActionDispatcher = (action: UnknownAction) => void;
 


### PR DESCRIPTION
RxBeach is TypeScript first, and should be strictly typed where
possible. AnyAction has been removed in favour of UnknownAction.

Where AnyAction in practice had `payload?: any` as a field,
UnknownAction has `payload?: unknown`.

Other uses of any in the codebase has also been reviewed - and have
found to only relate to
 - Error subject
 - Implementations
 - Tests