### PR TITLE
Test types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,12 +17,13 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['*.tests.ts'],
+      files: ['*.tspec.ts'],
       env: {
         mocha: true,
       },
       rules: {
         '@typescript-eslint/no-unused-vars': ['off'],
+        'prefer-const': ['off'],
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@typescript-eslint/eslint-plugin": "2.8.0",
     "@typescript-eslint/parser": "2.8.0",
     "ava": "2.4.0",
+    "conditional-type-checks": "1.0.4",
     "coveralls": "3.0.8",
     "eslint": "6.6.0",
     "eslint-config-prettier": "6.7.0",

--- a/src/internal/types.tspec.ts
+++ b/src/internal/types.tspec.ts
@@ -1,0 +1,37 @@
+import { Has, AssertFalse } from 'conditional-type-checks';
+import {
+  ActionWithoutPayload,
+  ActionWithPayload,
+  ActionCreatorWithPayload,
+  ActionCreatorWithoutPayload,
+} from 'rxbeach';
+import {
+  UnknownAction,
+  UnknownActionCreator,
+  UnknownActionCreatorWithPayload,
+} from 'rxbeach/internal';
+
+const any = undefined as any;
+const actionWithPayload = any as ActionWithPayload<any>;
+const actionWithoutPayload = any as ActionWithoutPayload;
+const actionCreatorWithoutPayload = any as ActionCreatorWithoutPayload;
+let actionCreatorWithPayload = any as ActionCreatorWithPayload<any>;
+
+let unknownAction: UnknownAction;
+let unknownActionCreatorWithPayload: UnknownActionCreatorWithPayload<unknown>;
+let unknownActionCreator: UnknownActionCreator;
+
+// ActionWithPayload and ActionWithoutPayload is assignable to UnknownAction
+unknownAction = actionWithoutPayload;
+unknownAction = actionWithPayload;
+
+type ActionCreatorWithoutPayload_is_not_assibleable_to_UnknownActionCreatorWithPayload = AssertFalse<
+  Has<ActionCreatorWithoutPayload, UnknownActionCreatorWithPayload<unknown>>
+>;
+
+// ActionCreatorWithPayload and UnkownActionCreatorWithPayload is assignable to each other
+unknownActionCreatorWithPayload = actionCreatorWithPayload;
+actionCreatorWithPayload = unknownActionCreatorWithPayload;
+
+unknownActionCreator = actionCreatorWithPayload;
+unknownActionCreator = actionCreatorWithoutPayload;

--- a/src/types/Action.tspec.ts
+++ b/src/types/Action.tspec.ts
@@ -1,0 +1,50 @@
+import { IsExact, AssertTrue, Has, AssertFalse } from 'conditional-type-checks';
+import { ActionWithPayload, ActionWithoutPayload, Action } from 'rxbeach';
+
+type ActionWithPayload_extends_ActionWithoutPayload = AssertTrue<
+  Has<ActionWithPayload<unknown>, ActionWithoutPayload>
+>;
+
+type Action_dispatches_to_ActionWithPayload = AssertTrue<
+  IsExact<Action<string>, ActionWithPayload<string>>
+>;
+type Action_dispatches_to_ActionWithoutPayload = AssertTrue<
+  IsExact<Action, ActionWithoutPayload>
+>;
+
+// Typescript does expansion of union types when they are generic arguments to
+// conditional types. This means that `Action<boolean>` is not the same as
+// `ActionWithPayload<boolean>`, but `ActionWithPayload<true> | ActionWithPayload<false>`
+// This is not what we want for RxBeach, but here we at least document how TS
+// actually treats union types for actions.
+
+type Action_expands_union_types1a = AssertTrue<
+  IsExact<Action<boolean>, ActionWithPayload<true> | ActionWithPayload<false>>
+>;
+type Action_expands_union_types1b = AssertFalse<
+  // This is how we would like it to work
+  IsExact<Action<boolean>, ActionWithPayload<boolean>>
+>;
+
+type Action_expands_union_types2a = AssertTrue<
+  IsExact<Action<Enum>, ActionWithPayload<Enum.A> | ActionWithPayload<Enum.B>>
+>;
+type Action_expands_union_types2b = AssertFalse<
+  // This is how we would like it to work
+  IsExact<Action<Enum>, ActionWithPayload<Enum>>
+>;
+
+type Action_Expands_union_types3a = AssertTrue<
+  IsExact<Action<Foo | Bar>, ActionWithPayload<Foo> | ActionWithPayload<Bar>>
+>;
+type Action_Expands_union_types3b = AssertFalse<
+  // This is how we would like it to work
+  IsExact<Action<Foo | Bar>, ActionWithPayload<Foo | Bar>>
+>;
+
+enum Enum {
+  A,
+  B,
+}
+type Foo = { foo: number };
+type Bar = { bar: string };

--- a/src/types/ActionCreator.tspec.ts
+++ b/src/types/ActionCreator.tspec.ts
@@ -1,0 +1,21 @@
+import { IsExact, AssertTrue, Has, AssertFalse } from 'conditional-type-checks';
+import {
+  ActionCreatorWithPayload,
+  ActionCreatorWithoutPayload,
+  ActionCreator,
+} from 'rxbeach';
+import { ActionCreatorCommon } from 'rxbeach/internal';
+
+type ActionCreatorWithPayload_extends_ActionCreatorCommon = AssertTrue<
+  Has<ActionCreatorWithPayload<unknown>, ActionCreatorCommon>
+>;
+type ActionCreatorWithoutPayload_extends_ActionCreatorCommon = AssertTrue<
+  Has<ActionCreatorWithoutPayload, ActionCreatorCommon>
+>;
+
+type ActionCreator_dispatches_to_ActionCreatorWithPayload = AssertTrue<
+  IsExact<ActionCreator<string>, ActionCreatorWithPayload<string>>
+>;
+type ActionCreator_dispatches_to_ActionCreatorWithoutPayload = AssertTrue<
+  IsExact<ActionCreator, ActionCreatorWithoutPayload>
+>;

--- a/src/types/helpers.tspec.ts
+++ b/src/types/helpers.tspec.ts
@@ -1,0 +1,7 @@
+import { AssertTrue, IsExact } from 'conditional-type-checks';
+import { ActionCreatorWithPayload, ExtractPayload } from 'rxbeach';
+
+type Payload = { foo: number };
+type ExtractPayload_extracts_payload = AssertTrue<
+  IsExact<ExtractPayload<ActionCreatorWithPayload<Payload>>, Payload>
+>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4239,10 +4239,10 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-ts-node@^8.4.1:
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.4.1.tgz#270b0dba16e8723c9fa4f9b4775d3810fd994b4f"
-  integrity sha512-5LpRN+mTiCs7lI5EtbXmF/HfMeCjzt7DH9CZwtkr6SywStrNQC723wG+aOWFiLNn7zT3kD/RnFqi3ZUfr4l5Qw==
+ts-node@8.5.2:
+  version "8.5.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.5.2.tgz#434f6c893bafe501a30b32ac94ee36809ba2adce"
+  integrity sha512-W1DK/a6BGoV/D4x/SXXm6TSQx6q3blECUzd5TN+j56YEMX3yPVMpHsICLedUw3DvGF3aTQ8hfdR9AKMaHjIi+A==
   dependencies:
     arg "^4.1.0"
     diff "^4.0.1"
@@ -4250,7 +4250,7 @@ ts-node@^8.4.1:
     source-map-support "^0.5.6"
     yn "^3.0.0"
 
-tsconfig-paths@^3.9.0:
+tsconfig-paths@3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
   integrity sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1130,6 +1130,11 @@ concordance@^4.0.0:
     semver "^5.5.1"
     well-known-symbols "^2.0.0"
 
+conditional-type-checks@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/conditional-type-checks/-/conditional-type-checks-1.0.4.tgz#491e2752006e1e049a11c8c26592b1b8535efbf9"
+  integrity sha512-3oKsfmRWuVLZ8WBmhHkCqLsa01mdX+H4aUkxesOXGYPAA2xJtrrlEfM5imvsz4Wv55RPaiSofgYEXikUQEW96g==
+
 configstore@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/configstore/-/configstore-4.0.0.tgz#5933311e95d3687efb592c528b922d9262d227e7"


### PR DESCRIPTION
@davidnegley uncovered some strange behaviour in regards to action creators of union types. 
This PR explores ways in which we can test the type definitions.

While developing I found a fundamental limitation in our current `Action` type: **It does not support any union types** - this includes disjunct types (`A | B`), booleans and enums.
A current workaround is to wrap the payload in an object.