### PR TITLE
Add void and payload overloads for actionCreator

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -97,5 +97,6 @@ module.exports = {
     strict: ['error', 'never'],
     'import/no-cycle': ['error'],
     'no-restricted-imports': ['error', { patterns: ['./*', '../*'] }],
+    'func-style': ['error', 'expression'],
   },
 };

--- a/src/actionCreator.spec.ts
+++ b/src/actionCreator.spec.ts
@@ -8,6 +8,10 @@ const action = myAction({ num: 3 }) as {
   payload: Payload;
   meta: { namespace?: string };
 };
+type AlternativePayload = { text: string };
+const unionAction = actionCreator<Payload | AlternativePayload>('union');
+const union1 = unionAction({ num: 4 });
+const union2 = unionAction({ text: 'hi' });
 
 test('actionCreator should create action creators and append the type', t => {
   t.is(action.type, myAction.type);
@@ -17,6 +21,11 @@ test('actionCreator should protect the type field', t => {
   t.throws(() => {
     (myAction as any).type = 'lol';
   }, TypeError);
+});
+test('actionCreator should create action objects with the payload', t => {
+  t.deepEqual(action.payload, { num: 3 });
+  t.deepEqual(union1.payload, { num: 4 });
+  t.deepEqual(union2.payload, { text: 'hi' });
 });
 test('actionCreator should create action objects with protected type', t => {
   t.throws(() => {

--- a/src/actionCreator.ts
+++ b/src/actionCreator.ts
@@ -1,18 +1,25 @@
-import { ActionCreator } from 'rxbeach';
-import { VoidPayload, UnknownActionCreator } from 'rxbeach/internal';
+import { ActionCreatorWithoutPayload, ActionCreatorWithPayload } from 'rxbeach';
 
-/**
- * Create an action creator with a given payload type
- *
- * @param type A name for debugging purposes
- * @template `Payload` - The payload type for the action
- * @returns An action creator function that accepts a payload as input, and
- *          returns a complete action object with that payload and a type unique
- *          to this action creator
- */
-export function actionCreator<Payload = VoidPayload>(
-  type: string
-): ActionCreator<Payload>;
+interface ActionCreatorFunc {
+  /**
+   * Create an action creator without a payload
+   *
+   * @param type A name for debugging purposes
+   * @returns An action creator function that creates complete action objects with
+   *          a type unique to this action creator
+   */
+  (type: string): ActionCreatorWithoutPayload;
+  /**
+   * Create an action creator with a given payload type
+   *
+   * @param type A name for debugging purposes
+   * @template `Payload` - The payload type for the action
+   * @returns An action creator function that accepts a payload as input, and
+   *          returns a complete action object with that payload and a type unique
+   *          to this action creator
+   */
+  <Payload extends {}>(type: string): ActionCreatorWithPayload<Payload>;
+}
 
 /**
  * Untyped `actionCreator`
@@ -21,7 +28,7 @@ export function actionCreator<Payload = VoidPayload>(
  * If you see this message in your IDE, you should investigate why TS did not
  * recognize the generic, typed overload of this function.
  */
-export function actionCreator(type: string): UnknownActionCreator {
+export const actionCreator: ActionCreatorFunc = (type: string) => {
   const action = (payload?: any) =>
     Object.freeze({
       type,
@@ -31,4 +38,4 @@ export function actionCreator(type: string): UnknownActionCreator {
   action.type = type;
 
   return Object.freeze(action);
-}
+};

--- a/src/actionCreator.tspec.ts
+++ b/src/actionCreator.tspec.ts
@@ -1,0 +1,30 @@
+import { actionCreator } from 'rxbeach';
+
+const booleanAction = actionCreator<boolean>('boolean');
+booleanAction(true);
+booleanAction(false);
+
+enum Enum {
+  A,
+  B,
+  C,
+}
+const enumAction = actionCreator<Enum>('enum');
+enumAction(Enum.A);
+enumAction(Enum.B);
+const e: Enum = Enum.C;
+enumAction(e);
+
+const unionAction = actionCreator<{} | number>('empty or number');
+unionAction({});
+unionAction(1);
+unionAction(2);
+
+type NumberGenerator = () => number;
+type BoolFunc = (a: boolean) => boolean;
+const unionFuncAction = actionCreator<NumberGenerator | BoolFunc>('functinos');
+unionFuncAction(() => 1);
+unionFuncAction(a => !a);
+
+const voidAction = actionCreator('void');
+voidAction();


### PR DESCRIPTION
These overloads allows TypeScript to properly infer Payloads for union payload
types.
Fixes #34.