### PR TITLE
Add carry operator

### DIFF
--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -2,5 +2,6 @@ export {
   ofType,
   extractPayload,
   withNamespace,
+  carry,
 } from 'rxbeach/operators/operators';
 export { mergeOperators } from 'rxbeach/operators/mergeOperators';


### PR DESCRIPTION
An operator to carry the initial payload through a new operator and returns it combined as an array with results from the operator.

```ts
action$.pipe(
  extractPayload(),
  carry(map(payload => payload.foo))
  tap(([payload, foo]) => {
    // `payload.foo === foo` equals `true`
  })
)
```
Big help from Tobias 🐧