### PR TITLE
Stream dependency analysis

### DIFF
--- a/src/internal/CombinationOperator.ts
+++ b/src/internal/CombinationOperator.ts
@@ -1,0 +1,53 @@
+import { Observable, OperatorFunction } from 'rxjs';
+
+export type CombinationOperator = {
+  <T, A>(name: string, a: Observable<A>): OperatorFunction<T, [T, A]>;
+  <T, A, B>(name: string, a: Observable<A>, b: Observable<B>): OperatorFunction<
+    T,
+    [T, A, B]
+  >;
+  <T, A, B, C>(
+    name: string,
+    a: Observable<A>,
+    b: Observable<B>,
+    c: Observable<C>
+  ): OperatorFunction<T, [T, A, B, C]>;
+  <T, A, B, C, D>(
+    name: string,
+    a: Observable<A>,
+    b: Observable<B>,
+    c: Observable<C>,
+    d: Observable<D>
+  ): OperatorFunction<T, [T, A, B, C, D]>;
+  <T, A, B, C, D, E>(
+    name: string,
+    a: Observable<A>,
+    b: Observable<B>,
+    c: Observable<C>,
+    d: Observable<D>,
+    e: Observable<E>
+  ): OperatorFunction<T, [T, A, B, C, D, E]>;
+  <T, A, B, C, D, E, F>(
+    name: string,
+    a: Observable<A>,
+    b: Observable<B>,
+    c: Observable<C>,
+    d: Observable<D>,
+    e: Observable<E>,
+    f: Observable<F>
+  ): OperatorFunction<T, [T, A, B, C, D, E, F]>;
+  <T, A, B, C, D, E, F, G>(
+    name: string,
+    a: Observable<A>,
+    b: Observable<B>,
+    c: Observable<C>,
+    d: Observable<D>,
+    e: Observable<E>,
+    f: Observable<F>,
+    g: Observable<G>
+  ): OperatorFunction<T, [T, A, B, C, D, E, F, G]>;
+  <T>(name: string, ...dependencies: Observable<unknown>[]): OperatorFunction<
+    T,
+    unknown
+  >;
+};

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -16,3 +16,4 @@ export {
   markCombine,
   markWithLatest,
 } from 'rxbeach/internal/markers';
+export { CombinationOperator } from 'rxbeach/internal/CombinationOperator';

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -9,3 +9,10 @@ export { RoutineFunc } from 'rxbeach/internal/routineFunc';
 export { coldMergeOperators } from 'rxbeach/operators/mergeOperators';
 export { defaultErrorSubject } from 'rxbeach/internal/defaultErrorSubject';
 export { rethrowErrorGlobally } from 'rxbeach/internal/rethrowErrorGlobally';
+export {
+  actionMarker,
+  markName,
+  markOfType,
+  markCombine,
+  markWithLatest,
+} from 'rxbeach/internal/markers';

--- a/src/internal/markers.spec.ts
+++ b/src/internal/markers.spec.ts
@@ -1,0 +1,115 @@
+import test from 'ava';
+import { Observable } from 'rxjs';
+import {
+  findMarker,
+  MarkerType,
+  markOfType,
+  actionMarker,
+  markName,
+  markCombine,
+  markWithLatest,
+  NameMarker,
+} from 'rxbeach/internal/markers';
+import { tap, map } from 'rxjs/operators';
+
+const source$ = new Observable<unknown>().pipe(markName('source'));
+const TOP_MARKER: NameMarker = {
+  type: MarkerType.NAME,
+  name: 'source',
+  sources: [null],
+};
+
+test('actionMarker creates actionMarker', t => {
+  t.deepEqual(actionMarker('heyo'), {
+    type: MarkerType.ACTION,
+    name: 'heyo',
+  });
+});
+
+test('markName marks name', t => {
+  t.deepEqual(findMarker(source$), TOP_MARKER);
+});
+
+test('markName includes parent marker', t => {
+  const piped$ = source$.pipe(markName('piped'));
+
+  t.deepEqual(findMarker(piped$), {
+    type: MarkerType.NAME,
+    name: 'piped',
+    sources: [TOP_MARKER],
+  });
+});
+
+test('markOfType marks action dependencies', t => {
+  const piped$ = source$.pipe(
+    markOfType([actionMarker('alpha'), actionMarker('bravo')])
+  );
+
+  t.deepEqual(findMarker(piped$), {
+    type: MarkerType.OF_TYPE,
+    sources: [
+      {
+        type: MarkerType.ACTION,
+        name: 'alpha',
+      },
+      {
+        type: MarkerType.ACTION,
+        name: 'bravo',
+      },
+    ],
+  });
+});
+
+test('combineMarker includes names of parents', t => {
+  const alpha$ = source$.pipe(markName('alpha'));
+  const bravo$ = source$.pipe(markName('bravo'));
+  const piped$ = source$.pipe(markCombine([alpha$, bravo$]));
+
+  t.deepEqual(findMarker(piped$), {
+    type: MarkerType.COMBINE,
+    sources: [
+      {
+        type: MarkerType.NAME,
+        name: 'alpha',
+        sources: [TOP_MARKER],
+      },
+      {
+        type: MarkerType.NAME,
+        name: 'bravo',
+        sources: [TOP_MARKER],
+      },
+    ],
+  });
+});
+
+test('injectMarker includes names of source and dependencies', t => {
+  const dependency$ = source$.pipe(markName('dependency'));
+  const piped$ = source$.pipe(markWithLatest(source$, [dependency$]));
+
+  t.deepEqual(findMarker(piped$), {
+    type: MarkerType.WITH_LATEST,
+    sources: [TOP_MARKER],
+    dependencies: [
+      {
+        type: MarkerType.NAME,
+        name: 'dependency',
+        sources: [TOP_MARKER],
+      },
+    ],
+  });
+});
+
+test('findMarker finds marker when before tap operator', t => {
+  const piped$ = source$.pipe(tap(() => null));
+
+  t.deepEqual(findMarker(piped$), TOP_MARKER);
+});
+
+test('findMarker finds marker when before tap and map operators', t => {
+  const piped$ = source$.pipe(
+    tap(() => null),
+    map(() => null)
+  );
+
+  t.deepEqual(findMarker(piped$), TOP_MARKER);
+});

--- a/src/internal/markers.ts
+++ b/src/internal/markers.ts
@@ -13,6 +13,7 @@ export const enum MarkerType {
   COMBINE,
   WITH_LATEST,
   NAME,
+  INVALID, // For test use
 }
 
 export type MarkerInterface = {
@@ -156,4 +157,49 @@ export const findMarker = (observable$: Observable<unknown>): Marker | null => {
   } else {
     return null;
   }
+};
+
+/**
+ * Detect possible glitches in a stream.
+ *
+ * A glitch occurs when a stream has multiple paths up its source or dependency
+ * trees to the same source. When that is the case, the streams could be
+ * evaluated in such an order so that that the stream recieves an
+ * illegal/partial state, or subscribers are notified multiple times for what
+ * should only be a single change.
+ *
+ * @param marker The marker to analyse the source and dependency trees for
+ *               glitches
+ * @param visited Implementation detail, please leave unset
+ * @param parent Implementation detail, please leave unset
+ * @returns An array of two markers, representing the two last steps in the path
+ *          to the common source or dependency
+ */
+export const detectGlitch = (
+  marker: MarkerInterface,
+  visited = new Map<string, Marker[]>(),
+  path: Marker[] = [marker as Marker]
+): [Marker[], Marker[]] | false => {
+  if (marker.sources === undefined && marker.dependencies === undefined) {
+    return false;
+  }
+
+  if (marker.name !== undefined) {
+    const previousPath = visited.get(marker.name);
+    visited.set(marker.name, path);
+
+    if (previousPath) return [previousPath, path];
+  }
+
+  const sources = [
+    ...(marker.sources || []),
+    ...(marker.dependencies || []),
+  ].filter((m): m is Marker => m !== null);
+
+  for (const source of sources) {
+    const possibleGlitch = detectGlitch(source, visited, [...path, source]);
+    if (possibleGlitch !== false) return possibleGlitch;
+  }
+
+  return false;
 };

--- a/src/internal/markers.ts
+++ b/src/internal/markers.ts
@@ -1,0 +1,159 @@
+import {
+  Operator,
+  Subscriber,
+  Subscribable,
+  TeardownLogic,
+  MonoTypeOperatorFunction,
+  Observable,
+} from 'rxjs';
+
+export const enum MarkerType {
+  ACTION,
+  OF_TYPE,
+  COMBINE,
+  WITH_LATEST,
+  NAME,
+}
+
+export type MarkerInterface = {
+  /**
+   * Type of the marker
+   */
+  readonly type: MarkerType;
+  /**
+   * The name of the stream
+   *
+   * Should be unique, and human readable.
+   */
+  readonly name?: string;
+  /**
+   * The streams that make this stream emit.
+   *
+   * `null` signifies streams without markers.
+   */
+  readonly sources?: (Marker | null)[];
+  /**
+   * Other streams this stream retrieves data from, but which does not trigger
+   * this stream to emit.
+   */
+  readonly dependencies?: (Marker | null)[];
+};
+
+type MarkerBase<M extends MarkerType = MarkerType> = {
+  readonly type: M;
+};
+
+type NamedMarker<M extends MarkerType> = MarkerBase<M> & {
+  readonly name: string;
+};
+
+/**
+ * A marker representing an action creator
+ */
+export type ActionMarker = NamedMarker<MarkerType.ACTION>;
+
+/**
+ * A marker to name a stream
+ */
+export type NameMarker = NamedMarker<MarkerType.NAME> & {
+  readonly sources: [Marker | null];
+};
+
+/**
+ * A marker for the `ofType` operator
+ */
+export type OfTypeMarker = MarkerBase<MarkerType.OF_TYPE> & {
+  readonly sources: ActionMarker[];
+};
+
+/**
+ * A marker for the `combineLatest` operator
+ */
+export type CombineMarker = MarkerBase<MarkerType.COMBINE> & {
+  readonly sources: (Marker | null)[];
+};
+
+/**
+ * A marker for the `withLatestFrom` operator
+ */
+export type WithLatestMarker = MarkerBase<MarkerType.WITH_LATEST> & {
+  readonly sources: [Marker | null];
+  readonly dependencies: (Marker | null)[];
+};
+
+export type Marker =
+  | WithLatestMarker
+  | CombineMarker
+  | OfTypeMarker
+  | NameMarker
+  | ActionMarker;
+
+export const actionMarker = (name: string): ActionMarker => ({
+  type: MarkerType.ACTION,
+  name,
+});
+
+export class MarkerOperator<T, M extends Marker> implements Operator<T, T> {
+  readonly marker: M;
+
+  constructor(marker: M) {
+    this.marker = marker;
+  }
+
+  call(subscriber: Subscriber<T>, source: Subscribable<T>): TeardownLogic {
+    return source.subscribe(subscriber);
+  }
+}
+
+export const markName = <T>(
+  name: string
+): MonoTypeOperatorFunction<T> => observable$ =>
+  observable$.lift(
+    new MarkerOperator({
+      type: MarkerType.NAME,
+      sources: [findMarker(observable$)],
+      name,
+    })
+  );
+
+export const markOfType = <T>(
+  sources: ActionMarker[]
+): MonoTypeOperatorFunction<T> => observable$ =>
+  observable$.lift(
+    new MarkerOperator({
+      type: MarkerType.OF_TYPE,
+      sources,
+    })
+  );
+
+export const markCombine = <T>(
+  sources$: Observable<unknown>[]
+): MonoTypeOperatorFunction<T> => observable$ =>
+  observable$.lift(
+    new MarkerOperator({
+      type: MarkerType.COMBINE,
+      sources: sources$.map(findMarker),
+    })
+  );
+
+export const markWithLatest = <T>(
+  source$: Observable<unknown>,
+  dependencies$: Observable<unknown>[]
+): MonoTypeOperatorFunction<T> => observable$ =>
+  observable$.lift(
+    new MarkerOperator({
+      type: MarkerType.WITH_LATEST,
+      sources: [findMarker(source$)],
+      dependencies: dependencies$.map(findMarker),
+    })
+  );
+
+export const findMarker = (observable$: Observable<unknown>): Marker | null => {
+  if (observable$.operator instanceof MarkerOperator) {
+    return observable$.operator.marker;
+  } else if (observable$.source instanceof Observable) {
+    return findMarker(observable$.source);
+  } else {
+    return null;
+  }
+};

--- a/src/operators/derivedStream.spec.ts
+++ b/src/operators/derivedStream.spec.ts
@@ -1,0 +1,52 @@
+import test from 'ava';
+import { markName } from 'rxbeach/internal';
+import { Observable } from 'rxjs';
+import { derivedStream } from 'rxbeach/operators';
+import { findMarker, MarkerType, NameMarker } from 'rxbeach/internal/markers';
+import { marbles } from 'rxjs-marbles/ava';
+
+test('derivedStream adds name and combine marker', t => {
+  const source$ = new Observable<unknown>().pipe(markName('source'));
+  const dependency$ = source$.pipe(markName('dependency'));
+
+  const derived$ = source$.pipe(derivedStream('derived', dependency$));
+
+  const sourceNameMarker: NameMarker = {
+    type: MarkerType.NAME,
+    name: 'source',
+    sources: [null],
+  };
+  const dependencyNameMarker: NameMarker = {
+    type: MarkerType.NAME,
+    name: 'dependency',
+    sources: [sourceNameMarker],
+  };
+  t.deepEqual(findMarker(derived$), {
+    type: MarkerType.NAME,
+    name: 'derived',
+    sources: [
+      {
+        type: MarkerType.COMBINE,
+        sources: [sourceNameMarker, dependencyNameMarker],
+      },
+    ],
+  });
+});
+
+test(
+  'derivedStream emits on emit from either source',
+  marbles(m => {
+    const letters = { a: 'A', b: 'B', c: 'C' };
+    const combined = {
+      B: ['A', 'B'] as [string, string],
+      C: ['C', 'B'] as [string, string],
+    };
+    const alpha$ = m.hot('   a-c', letters);
+    const bravo$ = m.hot('   -b-', letters);
+    const combined$ = m.hot('-BC', combined);
+
+    m.expect(alpha$.pipe(derivedStream('combined', bravo$))).toBeObservable(
+      combined$
+    );
+  })
+);

--- a/src/operators/derivedStream.ts
+++ b/src/operators/derivedStream.ts
@@ -1,0 +1,23 @@
+import { Observable, OperatorFunction } from 'rxjs';
+import { combineLatest } from 'rxjs/operators';
+import { markCombine, markName, CombinationOperator } from 'rxbeach/internal';
+
+/**
+ * Make this stream a derived stream of its source and dependencies
+ *
+ * This is basically an annotated version of the `combineLatest` operator that
+ * adds markers so the stream can be analyzed.
+ *
+ * @param name The unique name of this stream
+ * @param dependencies The dependencies of this stream
+ * @see combineLatest
+ */
+export const derivedStream: CombinationOperator = (
+  name: string,
+  ...dependencies: Observable<unknown>[]
+): OperatorFunction<any, any> => observable$ =>
+  observable$.pipe(
+    combineLatest(...dependencies),
+    markCombine([observable$, ...dependencies]),
+    markName(name)
+  );

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -7,3 +7,4 @@ export {
 } from 'rxbeach/operators/operators';
 export { mergeOperators } from 'rxbeach/operators/mergeOperators';
 export { derivedStream } from 'rxbeach/operators/derivedStream';
+export { withStreams } from 'rxbeach/operators/withStreams';

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -6,3 +6,4 @@ export {
   apply,
 } from 'rxbeach/operators/operators';
 export { mergeOperators } from 'rxbeach/operators/mergeOperators';
+export { derivedStream } from 'rxbeach/operators/derivedStream';

--- a/src/operators/operators.spec.ts
+++ b/src/operators/operators.spec.ts
@@ -14,7 +14,9 @@ import {
 } from 'rxbeach/operators';
 import { mockAction } from 'rxbeach/internal/testUtils';
 import { map } from 'rxjs/operators';
-import { pipe } from 'rxjs';
+import { Observable, pipe } from 'rxjs';
+import { UnknownAction } from 'rxbeach/internal';
+import { findMarker, MarkerType } from 'rxbeach/internal/markers';
 
 const extractsPayload: Macro<[any]> = (t, payload) =>
   marbles(m => {
@@ -71,6 +73,20 @@ test(
     m.expect(source.pipe(ofType(voidAction))).toBeObservable(expected);
   })
 );
+
+test('ofType should add a stream marker', t => {
+  const piped$ = new Observable<UnknownAction>().pipe(ofType(voidAction));
+
+  t.deepEqual(findMarker(piped$), {
+    type: MarkerType.OF_TYPE,
+    sources: [
+      {
+        type: MarkerType.ACTION,
+        name: voidAction.type,
+      },
+    ],
+  });
+});
 
 test(
   'ofType should filter multiple actions that are mix of void and not void',

--- a/src/operators/operators.ts
+++ b/src/operators/operators.ts
@@ -1,10 +1,12 @@
-import { OperatorFunction, MonoTypeOperatorFunction, of } from 'rxjs';
+import { OperatorFunction, MonoTypeOperatorFunction, of, pipe } from 'rxjs';
 import { map, filter, withLatestFrom, flatMap } from 'rxjs/operators';
 import { ActionWithPayload, ActionWithoutPayload } from 'rxbeach';
 import {
   UnknownActionCreatorWithPayload,
   UnknownActionCreator,
   UnknownAction,
+  actionMarker,
+  markOfType,
 } from 'rxbeach/internal';
 
 interface OfType {
@@ -74,7 +76,10 @@ export const ofType: OfType = ((
 ): OperatorFunction<UnknownAction, UnknownAction> => {
   const types = new Set(targetTypes.map(({ type }) => type));
 
-  return filter((action: UnknownAction) => types.has(action.type));
+  return pipe(
+    filter((action: UnknownAction) => types.has(action.type)),
+    markOfType([...types].map(actionMarker))
+  );
 }) as any; // Implementation is untyped
 
 /**

--- a/src/operators/withStreams.spec.ts
+++ b/src/operators/withStreams.spec.ts
@@ -1,0 +1,53 @@
+import test from 'ava';
+import { markName } from 'rxbeach/internal';
+import { Observable } from 'rxjs';
+import { withStreams } from 'rxbeach/operators';
+import { findMarker, MarkerType, NameMarker } from 'rxbeach/internal/markers';
+import { marbles } from 'rxjs-marbles/ava';
+
+test('derivedStream adds name and combine marker', t => {
+  const source$ = new Observable<unknown>().pipe(markName('source'));
+  const dependency$ = source$.pipe(markName('dependency'));
+
+  const derived$ = source$.pipe(withStreams('derived', dependency$));
+
+  const sourceNameMarker: NameMarker = {
+    type: MarkerType.NAME,
+    name: 'source',
+    sources: [null],
+  };
+  const dependencyNameMarker: NameMarker = {
+    type: MarkerType.NAME,
+    name: 'dependency',
+    sources: [sourceNameMarker],
+  };
+  t.deepEqual(findMarker(derived$), {
+    type: MarkerType.NAME,
+    name: 'derived',
+    sources: [
+      {
+        type: MarkerType.WITH_LATEST,
+        sources: [sourceNameMarker],
+        dependencies: [dependencyNameMarker],
+      },
+    ],
+  });
+});
+
+test(
+  'derivedStream emits on emit from source',
+  marbles(m => {
+    const letters = { a: 'A', b: 'B', c: 'C' };
+    const combined = {
+      B: ['A', 'B'] as [string, string],
+      C: ['C', 'B'] as [string, string],
+    };
+    const alpha$ = m.hot('   a-c', letters);
+    const bravo$ = m.hot('   -b-', letters);
+    const combined$ = m.hot('--C', combined);
+
+    m.expect(alpha$.pipe(withStreams('combined', bravo$))).toBeObservable(
+      combined$
+    );
+  })
+);

--- a/src/operators/withStreams.ts
+++ b/src/operators/withStreams.ts
@@ -1,0 +1,27 @@
+import { Observable, OperatorFunction } from 'rxjs';
+import { withLatestFrom } from 'rxjs/operators';
+import {
+  markWithLatest,
+  markName,
+  CombinationOperator,
+} from 'rxbeach/internal';
+
+/**
+ * Get data from other streams
+ *
+ * This is basically an annotated version of the `withLatestFrom` operator that
+ * adds markers so the stream can be analyzed.
+ *
+ * @param name The unique name of this stream
+ * @param dependencies$ The dependencies of this stream
+ * @see withLatestFrom
+ */
+export const withStreams: CombinationOperator = (
+  name: string,
+  ...dependencies$: Observable<unknown>[]
+): OperatorFunction<any, any> => observable$ =>
+  observable$.pipe(
+    withLatestFrom(...dependencies$),
+    markWithLatest(observable$, dependencies$),
+    markName(name)
+  );


### PR DESCRIPTION
This PR adds the tools we need to analyze how streams depend on each other.

The building blocks of this is as follows:
- `Marker` - A simple object which says something about how a stream is built up. The markers actually represent a stream as a tree in itself. They tell us:
    - The name of the stream
    - The sources of the stream (streams which updates leads to this stream updating)
    - The dependencies of the stream (streams which we retrieve data from)
- `MarkerOperator` - A no-op operator that places a marker on a stream
- `findMarker` - A function which recursively looks at the operators and sources for a stream to find the closest marker

Have a look at the test for `derivedStream` to see how the structure might look.