### PR TITLE
Remove runtime overhead of markers

### DIFF
--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -17,4 +17,6 @@ export {
   markWithLatestFrom,
   markMerge,
   markZip,
+  MarkedObservable,
+  findMarker,
 } from 'rxbeach/internal/markers';

--- a/src/operators/decorated.ts
+++ b/src/operators/decorated.ts
@@ -4,8 +4,9 @@ import {
   markMerge,
   markCombineLatest,
   markWithLatestFrom,
+  findMarker,
+  MarkedObservable,
 } from 'rxbeach/internal';
-import { findMarker, MarkerOperator } from 'rxbeach/internal/markers';
 
 export const merge = ((...sources: Observable<unknown>[]) => (
   observable$: Observable<unknown>
@@ -37,5 +38,5 @@ export const startWith = ((...args: any) => (
   const startWith$ = observable$.pipe(operators.startWith(...args));
   const marker = findMarker(observable$);
   if (marker === null) return startWith$;
-  else return startWith$.lift(new MarkerOperator(marker));
+  else return new MarkedObservable(startWith$, marker);
 }) as typeof operators.startWith;


### PR DESCRIPTION
Previously all markers would add an extra function call for each emitted
value in an observable. This was because the markers where added by
using `Observable.lift`, which leaves it to the operator to handle
emitted values.

This new implementation just extends Observable with the marker field,
and lets the Observable implementation handle subscribing to the source.
This means we don't add any extra function calls for the emitted values
to pass through.

As a side note - notice how we didn't need to change a single test, and they are all still passing with 100% line coverage.