### PR TITLE
feat: Reducer constructor returns a reducer function

### DIFF
--- a/examples/reducers.spec.ts
+++ b/examples/reducers.spec.ts
@@ -1,4 +1,9 @@
-import { actionCreator, reducer, combineReducers, ReducerEntry } from 'rxbeach';
+import {
+  actionCreator,
+  reducer,
+  combineReducers,
+  RegisteredReducer,
+} from 'rxbeach';
 import test from 'ava';
 import { marbles } from 'rxjs-marbles/ava';
 
@@ -8,7 +13,7 @@ const incrementMany = actionCreator<number>('[increment] many');
 
 // Our reducers
 type CounterState = number;
-type CounterReducer = ReducerEntry<CounterState>;
+type CounterReducer = RegisteredReducer<CounterState>;
 
 // Style 1 - Define the state type on state argument
 const handleOne = reducer(incrementOne, (prev: CounterState) => prev + 1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export {
   reducer,
   combineReducers,
   Reducer,
-  ReducerEntry,
+  RegisteredReducer,
 } from 'rxbeach/reducer';
 
 export {

--- a/src/reducer.spec.ts
+++ b/src/reducer.spec.ts
@@ -1,6 +1,7 @@
 import { reducer, combineReducers, actionCreator } from 'rxbeach';
 import test from 'ava';
 import { marbles } from 'rxjs-marbles/ava';
+import sinon from 'sinon';
 
 const throwErrorFn = (): number => {
   throw 'error';
@@ -9,10 +10,8 @@ const incrementOne = actionCreator('[increment] one');
 const decrement = actionCreator('[increment] decrement');
 const incrementMany = actionCreator<number>('[increment] many');
 
-const handleOne = reducer(
-  incrementOne,
-  (accumulator: number) => accumulator + 1
-);
+const incrementOneHandler = sinon.spy((accumulator: number) => accumulator + 1);
+const handleOne = reducer(incrementOne, incrementOneHandler);
 const handleMany = reducer(
   incrementMany,
   (accumulator: number, increment) => accumulator + increment
@@ -32,7 +31,9 @@ const outputs = {
 };
 
 test('reducer should store reducer function', t => {
-  t.deepEqual(handleDecrement, [[decrement], throwErrorFn]);
+  incrementOneHandler.resetHistory();
+  handleOne(1);
+  t.assert(incrementOneHandler.called);
 });
 
 test(


### PR DESCRIPTION
This commit makes the reducer constructor (`reducer`) return a function
that can be called like a plain reducer function. This allows for easier
composition of reducers.

BREAKING CHANGE: `ReducerEntry` has been renamed to `RegisteredReducer`,
and changed shape from an array to a function with a `trigger` property.