### PR TITLE
ARD-4020 Implemented state stream tooling with tests (WIP)

### DIFF
--- a/src/reduceState.spec.ts
+++ b/src/reduceState.spec.ts
@@ -1,0 +1,149 @@
+import { reducer, actionCreator } from 'rxbeach';
+import untypedTest from 'ava';
+import { marbles } from 'rxjs-marbles/ava';
+import sinon from 'sinon';
+import { reduceState } from 'rxbeach/reduceState';
+import { of, Subject } from 'rxjs';
+import { stubRethrowErrorGlobally } from 'rxbeach/internal/testUtils';
+
+const throwErrorFn = (): number => {
+  throw errors.e;
+};
+const incrementOne = actionCreator('[increment] one');
+const decrement = actionCreator('[increment] decrement');
+const incrementMany = actionCreator<number>('[increment] many');
+
+const incrementOneHandler = sinon.spy((accumulator: number) => accumulator + 1);
+const handleOne = reducer(incrementOne, incrementOneHandler);
+const test = stubRethrowErrorGlobally(untypedTest);
+const handleDecrementWithError = reducer(decrement, throwErrorFn);
+
+const actions = {
+  '1': incrementOne(),
+  '2': incrementMany(2),
+  d: decrement(),
+};
+const words = {
+  a: '1',
+  b: '12',
+};
+const numbers = {
+  '1': 1,
+  '2': 2,
+  '3': 3,
+  '4': 4,
+  '5': 5,
+  '6': 6,
+  '7': 7,
+};
+const errors = {
+  e: 'error',
+};
+
+test(
+  'reduceState should subscribe to action$ and emit initial state synchronously upon subscription',
+  marbles(m => {
+    const defaultState = 3;
+    const action$ = m.hot('  -');
+    const expected$ = m.hot('3', numbers);
+    const state$ = action$.pipe(reduceState('testStream', defaultState, []));
+
+    m.expect(action$).toHaveSubscriptions(['^']);
+    m.expect(state$).toBeObservable(expected$);
+  })
+);
+
+test(
+  'reduceState should only emit the latest state processed at the current frame',
+  marbles(m => {
+    const action$ = m.hot('  --1-', actions);
+    const word$ = m.hot('    a-a ', words);
+    const expected$ = m.hot('2-4', numbers);
+    const defaultState = 1;
+
+    const handleWord = reducer(
+      word$,
+      (state: number, word) => state + word.length
+    );
+    const state$ = action$.pipe(
+      reduceState('testStream', defaultState, [handleOne, handleWord])
+    );
+
+    m.expect(state$).toBeObservable(expected$);
+  })
+);
+
+test('reduceState should call reducer once when there are multiple subs', async t => {
+  const defaultState = 1;
+  incrementOneHandler.resetHistory();
+  const action$ = of(incrementOne());
+  const state$ = action$.pipe(
+    reduceState('testStream', defaultState, [handleOne])
+  );
+  const sub1 = state$.subscribe();
+  const sub2 = state$.subscribe();
+  t.assert(incrementOneHandler.calledOnce);
+  sub1.unsubscribe();
+  sub2.unsubscribe();
+});
+
+test(
+  'reduceState should share state and not reset as long as it has one subscriber',
+  marbles(m => {
+    const defaultState = 1;
+    const action$ = m.hot('      ----1-----1', actions);
+    const sub1 = '               --^--!';
+    const sub2 = '               ---------^--!';
+    const foreverSub = '         ^---------------';
+    const expected$ = m.hot('    1---2-----3-----', numbers);
+    const sub1Expected$ = m.hot('--1-2-----------', numbers);
+    const sub2Expected$ = m.hot('---------23-----', numbers);
+    const state$ = action$.pipe(
+      reduceState('testStream', defaultState, [handleOne])
+    );
+
+    m.expect(state$, foreverSub).toBeObservable(expected$);
+    m.expect(state$, sub1).toBeObservable(sub1Expected$);
+    m.expect(state$, sub2).toBeObservable(sub2Expected$);
+  })
+);
+
+test(
+  'reduceState should reset state when it has no subscribers',
+  marbles(m => {
+    const defaultState = 1;
+    const action$ = m.hot('      1--1---1---1-', actions);
+    const sub1 = '               --^--!--------';
+    const sub2 = '               ---------^---!';
+    const sub1Expected$ = m.hot('--12----------', numbers);
+    const sub2Expected$ = m.hot('---------1-2-', numbers);
+    const state$ = action$.pipe(
+      reduceState('testStream', defaultState, [handleOne])
+    );
+
+    m.expect(state$, sub1).toBeObservable(sub1Expected$);
+    m.expect(state$, sub2).toBeObservable(sub2Expected$);
+  })
+);
+
+test(
+  'reduceState catches errors and emits them to error subject',
+  marbles(m => {
+    const action$ = m.hot('  1d1', actions);
+    const expected$ = m.hot('2-3', numbers);
+    const errorMarbles = '   -e-';
+    const error$ = new Subject<any>();
+
+    m.expect(error$).toBeObservable(errorMarbles, errors);
+    m.expect(
+      action$.pipe(
+        reduceState(
+          'testStream',
+          1,
+          [handleOne, handleDecrementWithError],
+          error$
+        )
+      )
+    ).toBeObservable(expected$);
+  })
+);

--- a/src/reduceState.ts
+++ b/src/reduceState.ts
@@ -1,0 +1,45 @@
+import { markName, UnknownAction, defaultErrorSubject } from 'rxbeach/internal';
+import { tag } from 'rxjs-spy/operators';
+import { shareReplay, startWith, debounceTime } from 'rxjs/operators';
+import { combineReducers, RegisteredReducer } from 'rxbeach/reducer';
+import { OperatorFunction, pipe, Subject } from 'rxjs';
+
+/**
+ * Create a state stream for a set of reducers.
+ *
+ * It is guaranteed that the state stream will always emit a value upon subscription.
+ *
+ * The state stream is ref counted, which means that the stream
+ * will reset to its `defaultState` when there are no subscribers.
+ *
+ * If you wish to persist the state throughout the application lifecycle,
+ * you should create a subscriber that never unsubscribes.
+ *
+ * The values emitted from the stream are shared between the subscribers,
+ * and the reducers are only ran once per input action.
+ *
+ * @param name A name for debugging purposes
+ * @param action$ The action stream
+ * @param defaultState The initial state of the state stream,
+ *                     which is emitted synchronously upon subscription
+ * @param reducers The reducer entries that are combined with `combineReducers`
+ * @see rxbeach.combineReducers
+ * @returns An stream that emits the reduced state
+ */
+export const reduceState = <State>(
+  name: string,
+  defaultState: State,
+  reducers: RegisteredReducer<State, any>[],
+  errorSubject: Subject<any> = defaultErrorSubject
+): OperatorFunction<UnknownAction, State> =>
+  pipe(
+    combineReducers(defaultState, reducers, errorSubject),
+    startWith(defaultState),
+    shareReplay({
+      refCount: true,
+      bufferSize: 1,
+    }),
+    debounceTime(0),
+    markName(name),
+    tag(name)
+  );

--- a/src/reducer.spec.ts
+++ b/src/reducer.spec.ts
@@ -17,7 +17,7 @@ const handleMany = reducer(
   incrementMany,
   (accumulator: number, increment) => accumulator + increment
 );
-const handleDecrement = reducer(decrement, throwErrorFn);
+const handleDecrementWithError = reducer(decrement, throwErrorFn);
 const alwaysReset = reducer([incrementOne, incrementMany, decrement], () => 5);
 
 const actions = {
@@ -105,7 +105,9 @@ test(
 
     m.expect(error$).toBeObservable(errorMarbles, errors);
     m.expect(
-      action$.pipe(combineReducers(1, [handleOne, handleDecrement], error$))
+      action$.pipe(
+        combineReducers(1, [handleOne, handleDecrementWithError], error$)
+      )
     ).toBeObservable(expected$);
   })
 );


### PR DESCRIPTION
The pattern for creating state streams is one of the few missing pieces in ardoq-front to fully make use of reducers from rxbeach, so I thought I would give this a go.

The goal is for this to replace `createReducedStateStream` in ardoq-front (and hopefully most cases of `createStateStream` now that we have data reducers).

### The proposal

  **reduceState guarantees that:**
  - a value is emitted upon subscription with startWith (state streams can't be lazy)
  - the stream producer is shared, if there are multiple subscriptions
    the reducers will only run once
  - the state stream producer lives on "forever" throughout the app lifecycle,
    subsequent subscriptions will always get the previous state calculation
    even though there are no subscribers (i.e. the stream is not refcounted)

  **WIP:**
  - a state stream forwards errors to an error subject and continues emitting values after an error occurs

_All of the above "properties" have unit tests in **reduceState.spec.ts**_

### Example

With this tooling you can define a state stream like so:
```typescript
const defaultState = 1;
const handleOne = reducer(incrementOne, incrementOneHandler);
const handleMany = reducer(
  incrementMany,
  (accumulator: number, increment) => accumulator + increment
);
const state$ = action$.pipe(
  reduceState('testStream', defaultState, [
    handleOne,
    handleMany,
  ])
);
``` 
