### PR TITLE
feat(reducers): combineReducers catches errors when reducing values

### DIFF
--- a/src/reducer.spec.ts
+++ b/src/reducer.spec.ts
@@ -2,9 +2,10 @@ import { reducer, combineReducers, actionCreator } from 'rxbeach';
 import test from 'ava';
 import { marbles } from 'rxjs-marbles/ava';
 import sinon from 'sinon';
+import { Subject } from 'rxjs';
 
 const throwErrorFn = (): number => {
-  throw 'error';
+  throw errors.e;
 };
 const incrementOne = actionCreator('[increment] one');
 const decrement = actionCreator('[increment] decrement');
@@ -35,6 +36,9 @@ const numbers = {
   '4': 4,
   '5': 5,
   '6': 6,
+};
+const errors = {
+  e: 'error',
 };
 
 test('reducer should store reducer function', t => {
@@ -92,13 +96,16 @@ test(
 );
 
 test(
-  'combineReducers should not silence errors',
+  'combineReducers catches errors and emits them to error subject',
   marbles(m => {
     const action$ = m.hot('  1d1', actions);
-    const expected$ = m.hot('2# ', numbers);
+    const expected$ = m.hot('2-3', numbers);
+    const errorMarbles = '   -e-';
+    const error$ = new Subject<any>();
 
+    m.expect(error$).toBeObservable(errorMarbles, errors);
     m.expect(
-      action$.pipe(combineReducers(1, [handleOne, handleDecrement]))
+      action$.pipe(combineReducers(1, [handleOne, handleDecrement], error$))
     ).toBeObservable(expected$);
   })
 );


### PR DESCRIPTION
  When an error is caught, it is emitted to an optional error subject,
  while the stream itself does not emit. This means that any subscribers
  will still have the previously emitted value.

--- 

While implementing #99, I found that it is practically impossible to implement error handling at another level if we wish to keep the original stream alive, so I suggest that we add error handling to combineReducers.

[Some useful reading about RxJS error handling confirms that:](https://iamturns.com/continue-rxjs-streams-when-errors-occur/)
> If an error is thrown within an operator, the stream will always complete.

This means that the only way we can avoid an error at a later level is by using `switchMap`, but this is not really desirable with `combineReducers`:
```typescript
export const reduceStateWithErrorHandling = <State>(
  name: string,
  defaultState: State,
  reducers: RegisteredReducer<State, any>[],
  errorSubject: Subject<any> = defaultErrorSubject
): OperatorFunction<UnknownAction, State> => {
  let previousState = defaultState;
  return pipe(
    switchMap(action =>
      of(action).pipe(
        combineReducers(previousState, reducers),
        catchError((err, stream) => {
          errorSubject.next(err);
          return stream.pipe(skip(1));
        }),
        // Filter out undefined emission from catchError
        filter(s => s !== undefined)
      )
    ),
    startWith(defaultState),
    shareReplay({
      refCount: false,
      bufferSize: 1,
    }),
    markName(name),
    tag(name),
    tap(value => {
      previousState = value;
    })
  );
};
```