### PR TITLE
ARD-3813 add 10 stream parameter overload

### DIFF
--- a/src/derivedStream.ts
+++ b/src/derivedStream.ts
@@ -68,6 +68,19 @@ export type DerivedStream = {
     h: Observable<H>,
     i: Observable<I>
   ): Observable<[A, B, C, D, E, F, G, H, I]>;
+  <A, B, C, D, E, F, G, H, I, J>(
+    name: string,
+    a: Observable<A>,
+    b: Observable<B>,
+    c: Observable<C>,
+    d: Observable<D>,
+    e: Observable<E>,
+    f: Observable<F>,
+    g: Observable<G>,
+    h: Observable<H>,
+    i: Observable<I>,
+    j: Observable<J>
+  ): Observable<[A, B, C, D, E, F, G, H, I, J]>;
   (name: string, ...dependencies: Observable<unknown>[]): Observable<unknown>;
 };
 

--- a/src/internal/routineFunc.ts
+++ b/src/internal/routineFunc.ts
@@ -90,7 +90,7 @@ export interface RoutineFunc {
   /**
    * See collectRoutines for documentation
    */
-  <A, B, C, D, E, F, G, H, I>(
+  <A, B, C, D, E, F, G, H, I, J>(
     fn1: Routine<A>,
     fn2: OperatorFunction<A, B>,
     fn3: OperatorFunction<B, C>,
@@ -100,6 +100,22 @@ export interface RoutineFunc {
     fn7: OperatorFunction<F, G>,
     fn8: OperatorFunction<G, H>,
     fn9: OperatorFunction<H, I>,
+    fn10: OperatorFunction<I, J>
+  ): Routine<J>;
+  /**
+   * See collectRoutines for documentation
+   */
+  <A, B, C, D, E, F, G, H, I, J>(
+    fn1: Routine<A>,
+    fn2: OperatorFunction<A, B>,
+    fn3: OperatorFunction<B, C>,
+    fn4: OperatorFunction<C, D>,
+    fn5: OperatorFunction<D, E>,
+    fn6: OperatorFunction<E, F>,
+    fn7: OperatorFunction<F, G>,
+    fn8: OperatorFunction<G, H>,
+    fn9: OperatorFunction<H, I>,
+    fn10: OperatorFunction<I, J>,
     ...fns: OperatorFunction<any, any>[]
   ): Routine<{}>;
 }


### PR DESCRIPTION
alphabet practice

trying to address this @ts-ignore https://github.com/ardoq/ardoq-front/blob/master/src/js/ardoq/streams/assets/assets$.ts#L249 for a call to `derivedStream` which just recently increased the number of streams passed to 10.