### PR TITLE
feat(react): add connect React HOC

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "husky": "4.2.3",
     "nyc": "15.0.0",
     "react": "16.13.1",
-    "react-test-renderer": "16.13.0",
+    "react-test-renderer": "16.13.1",
     "rimraf": "3.0.2",
     "rxjs": "6.5.4",
     "rxjs-marbles": "6.0.0",

--- a/src/react/connect.spec.ts
+++ b/src/react/connect.spec.ts
@@ -1,0 +1,141 @@
+import testUntyped from 'ava';
+import { act, create, ReactTestRenderer } from 'react-test-renderer';
+import React from 'react';
+import { empty, of, BehaviorSubject } from 'rxjs';
+import { connect } from './connect';
+import { spy, SinonSpy } from 'sinon';
+import { TestInterface } from 'ava';
+
+type Props = { msg: string; num?: number };
+const initialProps = { msg: 'hello' };
+const secondProps = { msg: 'second' };
+const additionalProps = { num: 3 };
+const secondAdditionalProps = { num: 7 };
+const WrappedComponent = ({ msg }: Props) => React.createElement('p', {}, msg);
+
+type Context = {
+  WrappedComponentSpy: SinonSpy<[Props], ReturnType<typeof WrappedComponent>>;
+};
+
+const test = testUntyped as TestInterface<Context>;
+
+test.beforeEach((t) => {
+  t.context.WrappedComponentSpy = spy(({ msg }: Props) =>
+    React.createElement('p', {}, msg)
+  );
+});
+
+test.afterEach((t) => t.context.WrappedComponentSpy.resetHistory());
+
+test('connect should render null on first render', (t) => {
+  const { WrappedComponentSpy } = t.context;
+  const HOComponent = connect(WrappedComponentSpy, empty());
+
+  let component: ReactTestRenderer;
+  act(() => {
+    component = create(React.createElement(HOComponent));
+  });
+
+  t.assert(WrappedComponentSpy.notCalled);
+  t.deepEqual(component!.toJSON(), null);
+});
+
+test('connect should immediately send props to wrapped component', (t) => {
+  const { WrappedComponentSpy } = t.context;
+  const HOComponent = connect(WrappedComponentSpy, of(initialProps));
+
+  act(() => {
+    create(React.createElement(HOComponent));
+  });
+
+  t.deepEqual(WrappedComponentSpy.firstCall.args[0], initialProps);
+});
+
+test('connect should re-render wrapped component on emitted props', (t) => {
+  const { WrappedComponentSpy } = t.context;
+  const props$ = new BehaviorSubject<Props>(initialProps);
+  const HOComponent = connect(WrappedComponentSpy, props$);
+
+  act(() => {
+    create(React.createElement(HOComponent));
+  });
+  t.deepEqual(WrappedComponentSpy.firstCall.args[0], initialProps);
+
+  act(() => {
+    props$.next(secondProps);
+  });
+  t.deepEqual(WrappedComponentSpy.secondCall.args[0], secondProps);
+});
+
+test('connect should unsubscribe stream when unmounted', async (t) => {
+  const props$ = new BehaviorSubject<Props>(initialProps);
+  const HOComponent = connect(WrappedComponent, props$);
+
+  let component: ReactTestRenderer;
+  act(() => {
+    component = create(React.createElement(HOComponent));
+  });
+
+  t.notDeepEqual(props$.observers, []);
+
+  act(() => {
+    component.unmount();
+  });
+
+  t.deepEqual(props$.observers, []);
+});
+
+test('connect should forward props', async (t) => {
+  const { WrappedComponentSpy } = t.context;
+  const HOComponent = connect(WrappedComponentSpy, of(initialProps));
+
+  act(() => {
+    create(React.createElement(HOComponent, additionalProps));
+  });
+
+  t.deepEqual(WrappedComponentSpy.firstCall?.args[0], {
+    ...additionalProps,
+    ...initialProps,
+  });
+});
+
+test('connect give streamed props precedence over forwarded props', (t) => {
+  const { WrappedComponentSpy } = t.context;
+  const HOComponent = connect(WrappedComponentSpy, of(initialProps));
+
+  act(() => {
+    create(
+      React.createElement(HOComponent, {
+        ...additionalProps,
+        msg: 'overriding should not work',
+      })
+    );
+  });
+
+  t.deepEqual(WrappedComponentSpy.firstCall?.args[0], {
+    ...additionalProps,
+    ...initialProps,
+  });
+});
+
+test('connect should propagate changes to forwarded props', async (t) => {
+  const { WrappedComponentSpy } = t.context;
+  const HOComponent = connect(WrappedComponentSpy, of(initialProps));
+
+  let component: ReactTestRenderer;
+  act(() => {
+    component = create(React.createElement(HOComponent, additionalProps));
+  });
+  act(() => {
+    component.update(React.createElement(HOComponent, secondAdditionalProps));
+  });
+
+  t.deepEqual(WrappedComponentSpy.firstCall?.args[0], {
+    ...additionalProps,
+    ...initialProps,
+  });
+  t.deepEqual(WrappedComponentSpy.secondCall?.args[0], {
+    ...secondAdditionalProps,
+    ...initialProps,
+  });
+});

--- a/src/react/connect.ts
+++ b/src/react/connect.ts
@@ -1,0 +1,34 @@
+import { useStream, NOT_YET_EMITTED } from './useStream';
+import { Observable } from 'rxjs';
+import React, { ComponentType } from 'react';
+
+/**
+ * Higher order component for connecting a component to a stream
+ *
+ * The stream does not need to provide all the properties the component expects,
+ * any missing properties will be required by the component returned from this
+ * component.
+ *
+ * Typescript does, in certain cases, allow for extra properties to be unpacked
+ * on a component. This means it may be possible to send props which would be
+ * provided by the stream. In these cases the values from the stream will
+ * override any values passed as props.
+ *
+ * @param WrappedComponent Component that will recieve props from the stream
+ * @param stream$ Stream that will provide props to the component
+ * @see useStream
+ */
+export const connect = <Props, Observed extends Partial<Props>>(
+  Component: ComponentType<Props>,
+  stream$: Observable<Observed>
+) => (props: Omit<Props, keyof Observed>) => {
+  const value = useStream(stream$);
+
+  if (value === NOT_YET_EMITTED) return null;
+
+  // Typescript doesn't recognize this as Observed & Props for some reason
+  // Question on StackOverflow: https://stackoverflow.com/q/60758084/1104307
+  const newProps = { ...props, ...value } as Props & Observed;
+
+  return React.createElement(Component, newProps);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3717,15 +3717,15 @@ react-is@^16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
   integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
 
-react-test-renderer@16.13.0:
-  version "16.13.0"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.13.0.tgz#39ba3bf72cedc8210c3f81983f0bb061b14a3014"
-  integrity sha512-NQ2S9gdMUa7rgPGpKGyMcwl1d6D9MCF0lftdI3kts6kkiX+qvpC955jNjAZXlIDTjnN9jwFI8A8XhRh/9v0spA==
+react-test-renderer@16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.13.1.tgz#de25ea358d9012606de51e012d9742e7f0deabc1"
+  integrity sha512-Sn2VRyOK2YJJldOqoh8Tn/lWQ+ZiKhyZTPtaO0Q6yNj+QDbmRkVFap6pZPy3YQk8DScRDfyqm/KxKYP9gCMRiQ==
   dependencies:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     react-is "^16.8.6"
-    scheduler "^0.19.0"
+    scheduler "^0.19.1"
 
 react@16.13.1:
   version "16.13.1"
@@ -4064,10 +4064,10 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-scheduler@^0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.0.tgz#a715d56302de403df742f4a9be11975b32f5698d"
-  integrity sha512-xowbVaTPe9r7y7RUejcK73/j8tt2jfiyTednOvHbA8JoClvMYCp+r8QegLwK/n8zWQAtZb1fFnER4XLBZXrCxA==
+scheduler@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
+  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
A higher order component for connecting react components to streams.
Builds upon the `useStream` hook, and is intended for use in class based components that can't use the hook themselves.

Rigid testing with `react-test-renderer`, which renders the components without a DOM. Have also chosen to not write any `tsx`, so we won't have to deal with more tooling.