### PR TITLE
feat: allow listening for subscribed markers

### DIFF
--- a/src/hooks.spec.ts
+++ b/src/hooks.spec.ts
@@ -1,0 +1,38 @@
+import test from 'ava';
+import { clearHooks, hookMarkers, notifyStreamSubscribed } from './hooks';
+import { never } from 'rxjs';
+import { markName } from './internal';
+import { MarkerType } from './internal/markers';
+
+test.afterEach(() => clearHooks());
+
+test('marker hooks are invoked', (t) => {
+  const stream = never().pipe(markName('test'));
+
+  hookMarkers((marker) => {
+    t.deepEqual(marker.type, MarkerType.NAME);
+  });
+
+  notifyStreamSubscribed(stream);
+});
+
+test('marker hooks are not invoked for streams without markers', (t) => {
+  hookMarkers(() => {
+    t.fail('hooks should not be invoked');
+  });
+
+  notifyStreamSubscribed(never());
+  t.pass();
+});
+
+test('marker hooks can be unsubscribed', (t) => {
+  const stream = never().pipe(markName('test'));
+
+  const unhook = hookMarkers(() => {
+    t.fail('hook should not be invoked');
+  });
+
+  unhook();
+  notifyStreamSubscribed(stream);
+  t.pass();
+});

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,0 +1,48 @@
+import { Marker, findMarker } from './internal/markers';
+import { Observable } from 'rxjs';
+
+type Hook<T> = (payload: T) => void;
+type RemoveHook = () => void;
+
+const markerHooks = new Set<Hook<Marker>>();
+
+/**
+ * Register a hook for new markers
+ *
+ * The hook will be invoked every time a stream with a marker is subscribed.
+ * This can be from `subscribeRoutine`, `useStream` or `connect`.
+ *
+ * @param hook The hook that will be invoked
+ * @returns A function to remove/unsubscribe the hook
+ */
+export const hookMarkers = (hook: Hook<Marker>): RemoveHook => {
+  markerHooks.add(hook);
+  return () => markerHooks.delete(hook);
+};
+
+/**
+ * Notify the hooks system that a stream has been subscribed.
+ *
+ * If a marker can be found on the observable, the marker hooks will be invoked.
+ *
+ * Can be used to invoke the marker hook for streams that are subscribed without
+ * RxBeach tooling.
+ *
+ * @param stream The stream that has been subscribed
+ * @see rxbeach/interal#findMarker
+ */
+export const notifyStreamSubscribed = (stream: Observable<unknown>) => {
+  const marker = findMarker(stream);
+  if (marker === null) return;
+
+  for (const hook of markerHooks) {
+    hook(marker);
+  }
+};
+
+/**
+ * Remove all hooks
+ */
+export const clearHooks = () => {
+  markerHooks.clear();
+};

--- a/src/internal/markers.spec.ts
+++ b/src/internal/markers.spec.ts
@@ -13,6 +13,8 @@ import {
   Marker,
   markMerge,
   markZip,
+  markView,
+  markRoutine,
 } from './markers';
 import {
   tap,
@@ -56,6 +58,25 @@ test('markName includes parent marker', (t) => {
 
   t.deepEqual(findMarker(piped$), {
     type: MarkerType.NAME,
+    name: 'piped',
+    sources: [TOP_MARKER],
+  });
+});
+
+test('markRoutine includes parent marker', (t) => {
+  const piped$ = source$.pipe(markRoutine());
+
+  t.deepEqual(findMarker(piped$), {
+    type: MarkerType.ROUTINE,
+    sources: [TOP_MARKER],
+  });
+});
+
+test('markView includes name and parent marker', (t) => {
+  const piped$ = source$.pipe(markView('piped'));
+
+  t.deepEqual(findMarker(piped$), {
+    type: MarkerType.VIEW,
     name: 'piped',
     sources: [TOP_MARKER],
   });

--- a/src/internal/markers.ts
+++ b/src/internal/markers.ts
@@ -168,44 +168,44 @@ export const markView = <T>(name?: string): MonoTypeOperatorFunction<T> => (
 export const markOfType = <T>(
   sources: ActionMarker[]
 ): MonoTypeOperatorFunction<T> => (observable$) =>
-    new MarkedObservable(observable$, {
-      type: MarkerType.OF_TYPE,
-      sources,
-    });
+  new MarkedObservable(observable$, {
+    type: MarkerType.OF_TYPE,
+    sources,
+  });
 
 export const markCombineLatest = <T>(
   sources$: Observable<unknown>[]
 ): MonoTypeOperatorFunction<T> => (observable$) =>
-    new MarkedObservable(observable$, {
-      type: MarkerType.COMBINE_LATEST,
-      sources: sources$.map(findMarker),
-    });
+  new MarkedObservable(observable$, {
+    type: MarkerType.COMBINE_LATEST,
+    sources: sources$.map(findMarker),
+  });
 
 export const markWithLatestFrom = <T>(
   source$: Observable<unknown>,
   dependencies$: Observable<unknown>[]
 ): MonoTypeOperatorFunction<T> => (observable$) =>
-    new MarkedObservable(observable$, {
-      type: MarkerType.WITH_LATEST_FROM,
-      sources: [findMarker(source$)],
-      dependencies: dependencies$.map(findMarker),
-    });
+  new MarkedObservable(observable$, {
+    type: MarkerType.WITH_LATEST_FROM,
+    sources: [findMarker(source$)],
+    dependencies: dependencies$.map(findMarker),
+  });
 
 export const markMerge = <T>(
   sources$: Observable<unknown>[]
 ): MonoTypeOperatorFunction<T> => (observable$) =>
-    new MarkedObservable(observable$, {
-      type: MarkerType.MERGE,
-      sources: sources$.map(findMarker),
-    });
+  new MarkedObservable(observable$, {
+    type: MarkerType.MERGE,
+    sources: sources$.map(findMarker),
+  });
 
 export const markZip = <T>(
   sources$: Observable<unknown>[]
 ): MonoTypeOperatorFunction<T> => (observable$) =>
-    new MarkedObservable(observable$, {
-      type: MarkerType.ZIP,
-      sources: sources$.map(findMarker),
-    });
+  new MarkedObservable(observable$, {
+    type: MarkerType.ZIP,
+    sources: sources$.map(findMarker),
+  });
 
 export const findMarker = (observable$: Observable<unknown>): Marker | null => {
   if (observable$ instanceof MarkedObservable) {

--- a/src/operators/mergeOperators.ts
+++ b/src/operators/mergeOperators.ts
@@ -1,5 +1,6 @@
-import { OperatorFunction, merge, pipe } from 'rxjs';
+import { OperatorFunction, pipe } from 'rxjs';
 import { share } from 'rxjs/operators';
+import { merge } from '../decoratedObservableCombiners';
 
 /**
  * Runs operators in parallel and merges their results
@@ -20,7 +21,7 @@ import { share } from 'rxjs/operators';
 export const coldMergeOperators = <T, R>(
   ...operators: OperatorFunction<T, R>[]
 ): OperatorFunction<T, R> => (source) =>
-  merge(...operators.map((operator) => source.pipe(operator)));
+    merge(...operators.map((operator) => source.pipe(operator)));
 
 /**
  * Runs operators in parallel and merges their results

--- a/src/operators/mergeOperators.ts
+++ b/src/operators/mergeOperators.ts
@@ -21,7 +21,7 @@ import { merge } from '../decoratedObservableCombiners';
 export const coldMergeOperators = <T, R>(
   ...operators: OperatorFunction<T, R>[]
 ): OperatorFunction<T, R> => (source) =>
-    merge(...operators.map((operator) => source.pipe(operator)));
+  merge(...operators.map((operator) => source.pipe(operator)));
 
 /**
  * Runs operators in parallel and merges their results

--- a/src/react/connect.ts
+++ b/src/react/connect.ts
@@ -2,6 +2,9 @@ import { useStream, NOT_YET_EMITTED } from './useStream';
 import { Observable } from 'rxjs';
 import React, { ComponentType } from 'react';
 
+const getComponentName = (Component: ComponentType<any>): string | undefined =>
+  Component.displayName || Component.name || undefined;
+
 /**
  * Higher order component for connecting a component to a stream
  *
@@ -22,7 +25,7 @@ export const connect = <Props, Observed extends Partial<Props>>(
   Component: ComponentType<Props>,
   stream$: Observable<Observed>
 ) => (props: Omit<Props, keyof Observed>) => {
-  const value = useStream(stream$);
+  const value = useStream(stream$, getComponentName(Component));
 
   if (value === NOT_YET_EMITTED) return null;
 

--- a/src/react/useStream.spec.ts
+++ b/src/react/useStream.spec.ts
@@ -1,7 +1,9 @@
 import test from 'ava';
 import { renderHook } from '@testing-library/react-hooks';
 import { useStream, NOT_YET_EMITTED } from './useStream';
-import { empty, Subject } from 'rxjs';
+import { empty, Subject, never } from 'rxjs';
+import { hookMarkers } from '../hooks';
+import { ViewMarker } from '../internal/markers';
 
 const second = 'A';
 
@@ -53,4 +55,12 @@ test('useStream unsubscribes, keeps latest value and subscribes new stream', (t)
   t.deepEqual(result.current, second);
   t.deepEqual(alpha.observers, []);
   t.deepEqual(bravo.observers.length, 1);
+});
+
+test('useStream invokes marker hooks', (t) => {
+  hookMarkers((marker) => {
+    t.deepEqual((marker as ViewMarker).name, 'Name');
+  });
+
+  renderHook(() => useStream(never(), 'Name'));
 });

--- a/src/react/useStream.ts
+++ b/src/react/useStream.ts
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Observable } from 'rxjs';
+import { notifyStreamSubscribed } from '../hooks';
+import { markView } from '../internal/markers';
 
 /**
  * Returned from `useStream` before first emit from the provided stream
@@ -47,10 +49,14 @@ export type NOT_YET_EMITTED = typeof NOT_YET_EMITTED;
  * @see useEffect
  * @see NOT_YET_EMITTED
  */
-export const useStream = <T>(source$: Observable<T>): T | NOT_YET_EMITTED => {
+export const useStream = <T>(
+  source$: Observable<T>,
+  name?: string
+): T | NOT_YET_EMITTED => {
   const [value, setValue] = useState<T | NOT_YET_EMITTED>(NOT_YET_EMITTED);
 
   useEffect(() => {
+    notifyStreamSubscribed(source$.pipe(markView(name)));
     const subscription = source$.subscribe(setValue);
 
     return () => subscription.unsubscribe();

--- a/src/routines.spec.ts
+++ b/src/routines.spec.ts
@@ -1,5 +1,5 @@
 import untypedTest from 'ava';
-import { Subject } from 'rxjs';
+import { Subject, never } from 'rxjs';
 import { map, filter } from 'rxjs/operators';
 import { marbles } from 'rxjs-marbles/ava';
 import { ActionWithPayload } from './types/Action';
@@ -11,6 +11,9 @@ import {
 } from './routines';
 import { mockAction, stubRethrowErrorGlobally } from './internal/testing/utils';
 import { extractPayload } from './operators/operators';
+import { ActionStream } from '.';
+import { hookMarkers } from './hooks';
+import { MarkerType } from './internal/markers';
 
 const test = stubRethrowErrorGlobally(untypedTest);
 
@@ -113,3 +116,10 @@ test(
     m.expect(error$).toBeObservable(errorMarbles, errors);
   })
 );
+
+test('subscribeRoutine invokes hooks', (t) => {
+  hookMarkers((marker) => {
+    t.deepEqual(marker.type, MarkerType.ROUTINE);
+  });
+  subscribeRoutine(never() as ActionStream, lettersRoutine);
+});


### PR DESCRIPTION
For our streams-to-ardoq functionality we need to have a sentral registry of streams / stream markers that can be used to build the graph of the streams. Previously we did this with the `streamRegistry` module in ardoq-front, which the stream tooling in `ardoq-front` hooked into.

With the introduction of `connect` and `useStream` in RxBeach, `ardoq-front` no longer has a means of registering streams, at least not without wrapping / decorating / replacing functions from RxBeach. 

Originally I wanted to keep RxBeach as free from global state as possible, which is why I came up with the hooks approach. It a simple callback-based event approach. I'm not at all sure about the naming. 

This PR adds a function for registering a callback to registered streams. The idea is that we could use this callback to build up the registry in `ardoq-front`. I am having some second thoughts now - maybe we should rather actually build the registry directly here in RxBeach?

### Added
- Markers for views and routines
- A simple hook system, for listening for subscribed streams
- hooks are invoked when routines are subscribed, or routines are connected to react views

### To investigate
- Can we "register" streams before they are subscribed?
- Will we manage to add a hook early enough in ardoq-front, to receive all the markers?
- We should add tooling for global subscriptions, so they are automatically subscribed.