### PR TITLE
feat(reducers): added performance measurements to combineReducers

### DIFF
--- a/src/internal/performance/performanceMeasurements.ts
+++ b/src/internal/performance/performanceMeasurements.ts
@@ -1,0 +1,43 @@
+import { defaultErrorSubject } from '../defaultErrorSubject';
+import { Subject } from 'rxjs';
+
+const PERFORMANCE_MARK_PREFIX = 'rxbeach';
+
+const isWindowPerformanceDefined = () =>
+  typeof window !== 'undefined' && window.performance;
+
+const getPerformanceMarker = (name: string) => {
+  return `${PERFORMANCE_MARK_PREFIX} - ${name}`;
+};
+
+const getStartMarker = (marker: string) => `${marker} - start`;
+const getEndMarker = (marker: string) => `${marker} - end`;
+
+export const startPerformanceMeasurement = (
+  name: string,
+  errorSubject: Subject<any> = defaultErrorSubject
+) => {
+  if (!isWindowPerformanceDefined()) return;
+  try {
+    const marker = getStartMarker(getPerformanceMarker(name));
+    window.performance.mark(marker);
+  } catch (e) {
+    errorSubject.next(e);
+  }
+};
+
+export const endPerformanceMeasurement = (
+  name: string,
+  errorSubject: Subject<any> = defaultErrorSubject
+) => {
+  if (!isWindowPerformanceDefined()) return;
+  const marker = getPerformanceMarker(name);
+  const startMarker = getStartMarker(marker);
+  const endMarker = getEndMarker(marker);
+  try {
+    window.performance.mark(endMarker);
+    window.performance.measure(marker, startMarker, endMarker);
+  } catch (e) {
+    errorSubject.next(e);
+  }
+};

--- a/src/operators/reduceState.ts
+++ b/src/operators/reduceState.ts
@@ -37,7 +37,10 @@ export const reduceState = <State>(
   errorSubject: Subject<any> = defaultErrorSubject
 ): OperatorFunction<UnknownAction, State> =>
   pipe(
-    combineReducers(defaultState, reducers, errorSubject),
+    combineReducers(defaultState, reducers, {
+      errorSubject,
+      performanceMarker: name,
+    }),
     startWith(defaultState),
     shareReplay({
       refCount: true,

--- a/src/persistentReducedStream.ts
+++ b/src/persistentReducedStream.ts
@@ -93,7 +93,7 @@ export const persistentReducedStream = <State>(
   errorSubject: Subject<any> = defaultErrorSubject
 ): StateStream<State> => {
   const reducedState$ = action$.pipe(
-    combineReducers(initialState, reducers, errorSubject),
+    combineReducers(initialState, reducers, { errorSubject }),
     markName(name),
     tag(name)
   );

--- a/src/reducer.spec.ts
+++ b/src/reducer.spec.ts
@@ -80,7 +80,7 @@ test(
 
     m.expect(error$).toBeObservable(errorMarbles, errors);
     m.expect(
-      action$.pipe(combineReducers(1, reducerArray, error$))
+      action$.pipe(combineReducers(1, reducerArray, { errorSubject: error$ }))
     ).toBeObservable(expected$);
   })
 );


### PR DESCRIPTION
If the window.performance API is available and a marker name is passed to
combineReducers it will add performance markers using the window.performance API.

The markers and measurements can be read and logged by interacting with
the performance API.

---
The benefit of using the window performance API is that they're available when using the browser for performance profiling:
![Screenshot 2020-04-30 16 07 29](https://user-images.githubusercontent.com/1349225/80720551-5ecbe080-8afd-11ea-9bd0-d4ea9741fa0d.png)
![Screenshot 2020-04-30 16 07 38](https://user-images.githubusercontent.com/1349225/80720545-58d5ff80-8afd-11ea-855b-8e7a42fb1ea5.png)


I first tried to implement this in a way that performance measurements would also work when window isn't available by falling back to using the node performance API, but it wasn't straight forward. Since we don't have a use-case for that yet I think this is fine.