### PR TITLE
feat: add withoutNamespace operator

### DIFF
--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -2,6 +2,7 @@ export {
   ofType,
   extractPayload,
   withNamespace,
+  withoutNamespace,
   carry,
   apply,
 } from './operators';

--- a/src/operators/operators.ts
+++ b/src/operators/operators.ts
@@ -107,6 +107,23 @@ export const withNamespace = (
   );
 
 /**
+ * Stream operator that excludes actions with the given namespace
+ *
+ * If no namespace is provided, it will exclude all actions that has any
+ * namespace
+ *
+ * @param excludedNamespace Optionally a specific namespace to exclude
+ */
+export const withoutNamespace = (
+  excludedNamespace?: string
+): MonoTypeOperatorFunction<UnknownAction> =>
+  filter(({ meta: { namespace } }) =>
+    excludedNamespace === undefined
+      ? namespace === undefined
+      : namespace !== excludedNamespace
+  );
+
+/**
  * Stream operator that carries the initial payload alongside the results
  * from the operator parameter
  *


### PR DESCRIPTION
This is a generalization of two utils I introduced in ardoq-front#7592
https://github.com/ardoq/ardoq-front/pull/7592/files#diff-5ef729189ec41118a686b2dec008e045R61-R69

I think it makes sense to introduce this as a single operator, though the behaviour actually changes between the 1-arg and 0-arg version. I think the name will still flow very naturally in both cases, though. 