### PR TITLE
feat: forward namespaces to reducers

### DIFF
--- a/src/persistentReducedStateStream.ts
+++ b/src/persistentReducedStateStream.ts
@@ -66,6 +66,7 @@ export class PersistentReducedStateStream<State> extends Observable<State> {
       .pipe(
         combineReducers(seed, this.reducers, {
           errorSubject: this.errorSubject,
+          namespace: this.namespace,
         }),
         markName(this.name),
         tag(this.name)

--- a/src/reducer.spec.ts
+++ b/src/reducer.spec.ts
@@ -121,3 +121,29 @@ test(
     ).toBeObservable(expected$);
   })
 );
+
+test(
+  'combineReducers should forward namespace',
+  marbles((m) => {
+    const action$ = m.hot('  1', actions);
+    const expected$ = m.hot('2', numbers);
+
+    const verifyNamespaceReducer = reducer(
+      actionCreators.incrementOne,
+      (_, __, namespace) => {
+        if (namespace === incrementMocks.namespace) {
+          return 2;
+        }
+        return 1;
+      }
+    );
+
+    m.expect(
+      action$.pipe(
+        combineReducers(1, [verifyNamespaceReducer], {
+          namespace: incrementMocks.namespace,
+        })
+      )
+    ).toBeObservable(expected$);
+  })
+);


### PR DESCRIPTION
The motivation for this change is to allow more reducers to be statically created. See [this example](https://github.com/ardoq/ardoq-front/blob/master/src/js/ardoq/search/QueryEditor/queryEditor%24.ts#L195-L212) from ardoq-front.

As you can see from the tests. The syntax is not ideal for void actions (with the underscores/unused arguments).