### PR TITLE
fix: order reducer overload from most to least complex

### DIFF
--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -59,39 +59,20 @@ const isStreamReducer = <State, Payload>(
 
 type ReducerCreator = {
   /**
-   * Define a reducer for an action with payload
+   * Define a reducer for a stream
    *
    * @see combineReducers
-   * @param actionCreator The action creator to assign this reducer to and
-   *                      extract payload type from
+   * @param source$ The stream which will trigger this reducer
    * @param reducer The reducer function
    * @template `State` - The state the reducer reduces to
-   * @template `Payload` - The payload of the action, fed to the reducer together
-   *                       with the state. Should be automatically extracted from
-   *                       the `actionCreator` parameter
+   * @template `Payload` - The type of values `source$` emits
    * @returns A registered reducer that can be passed into `combineReducers`, or
    *          called directly as if it was the `reducer` parameter itself.
    */
   <State, Payload>(
-    actionCreator: UnknownActionCreatorWithPayload<Payload>,
+    source$: Observable<Payload>,
     reducer: Reducer<State, Payload>
   ): RegisteredReducer<State, Payload>;
-
-  /**
-   * Define a reducer for an action without payload
-   *
-   * @see combineReducers
-   * @param actionCreator The action creator to assign this reducer to and
-   *                      extract payload type from
-   * @param reducer The reducer function
-   * @template `State` - The state the reducer reduces to
-   * @returns A registered reducer that can be passed into `combineReducers`, or
-   *          called directly as if it was the `reducer` parameter itself.
-   */
-  <State>(
-    actionCreator: UnknownActionCreator,
-    reducer: Reducer<State, VoidPayload>
-  ): RegisteredReducer<State, VoidPayload>;
 
   /**
    * Define a reducer for multiple actions with overlapping payload
@@ -145,20 +126,39 @@ type ReducerCreator = {
   ): RegisteredReducer<State, VoidPayload>;
 
   /**
-   * Define a reducer for a stream
+   * Define a reducer for an action with payload
    *
    * @see combineReducers
-   * @param source$ The stream which will trigger this reducer
+   * @param actionCreator The action creator to assign this reducer to and
+   *                      extract payload type from
    * @param reducer The reducer function
    * @template `State` - The state the reducer reduces to
-   * @template `Payload` - The type of values `source$` emits
+   * @template `Payload` - The payload of the action, fed to the reducer together
+   *                       with the state. Should be automatically extracted from
+   *                       the `actionCreator` parameter
    * @returns A registered reducer that can be passed into `combineReducers`, or
    *          called directly as if it was the `reducer` parameter itself.
    */
   <State, Payload>(
-    source$: Observable<Payload>,
+    actionCreator: UnknownActionCreatorWithPayload<Payload>,
     reducer: Reducer<State, Payload>
   ): RegisteredReducer<State, Payload>;
+
+  /**
+   * Define a reducer for an action without payload
+   *
+   * @see combineReducers
+   * @param actionCreator The action creator to assign this reducer to and
+   *                      extract payload type from
+   * @param reducer The reducer function
+   * @template `State` - The state the reducer reduces to
+   * @returns A registered reducer that can be passed into `combineReducers`, or
+   *          called directly as if it was the `reducer` parameter itself.
+   */
+  <State>(
+    actionCreator: UnknownActionCreator,
+    reducer: Reducer<State, VoidPayload>
+  ): RegisteredReducer<State, VoidPayload>;
 };
 
 export const reducer: ReducerCreator = <State>(


### PR DESCRIPTION
This gives nicer error messages that will more often match the actual problem the user has,
though there is still a high chance that TypeScript will show the "wrong" error.

The old order was:
 1. single action with payload
 2. single action without payload
 3. multiple actions with overlapping payload
 4. multiple actions without overlapping payloads
 5. multiple actions without payloads
 6. stream

The new order is:
 1. stream
 2. multiple actions with overlapping payload
 3. multiple actions without overlapping payloads
 4. multiple actions without payloads
 5. single action with payload
 6. single action without payload

It's important to remember that TypeScript will choose the first overload which doesn't give an error for the function call, or display the error of the last overload. However, because of how TS handles errors (or something like that), TS can still choose an earlier overload with error in the argument, if it finds there is no error in the function call itself (which I haven't fully understood the rationale behind yet).

I think the most common error is the return type of the reducer not matching the state type, and we more often have payloads than not. Because of this, we should ideally have the "single action with payload" overload last, but because of what I mentioned above, this would mean all reducers are interpreted as reducers for actions without payloads (because an action with payload is assignable to an action without a payload), so that's a no-go.
