### PR TITLE
fix: ARD-9960 fixed carry bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 .nyc_output
 coverage
+.idea

--- a/src/operators/operators.spec.ts
+++ b/src/operators/operators.spec.ts
@@ -223,7 +223,19 @@ test(
     ).toBeObservable(expected);
   })
 );
-
+test(
+  'carry only subscribes to the original observable once',
+  marbles((m) => {
+    const source$ = m.cold(' f', { f });
+    const expected = m.hot('1', {
+      '1': [f.payload, f.payload.foo] as [FooPayload, number],
+    });
+    m.expect(
+      source$.pipe(extractPayload(), carry(map((e) => e.foo)))
+    ).toBeObservable(expected);
+    m.expect(source$).toHaveSubscriptions(['  ^']);
+  })
+);
 test(
   'apply should provide context to operators',
   marbles((m) => {


### PR DESCRIPTION
The carry operator had a bug that caused it to subscribe twice to the routines where it was used. More detailed description. 
TLDR: caused by difference between hot vs cold observables 