### PR TITLE
chore: expose useStream hook

### DIFF
--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,1 +1,1 @@
-export { connect } from './connect';
+export { connect, useStream } from './connect';


### PR DESCRIPTION
It's all in place, just the hook was not exposed from the package, so it cannot be used.