### PR TITLE
feat(react): add `connectInstance` function

### DIFF
--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,1 +1,1 @@
-export { connect, useStream } from './connect';
+export { connect, connectInstance, useStream } from './connect';


### PR DESCRIPTION
The new `connectInstance` function works the same as `connect`, but
takes a function that takes an instance name and produces
`ObservableInput`. This is well suited for namespaced streams.