### PR TITLE
feat: enable HMR of persistentReducedStreams (opt in)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,21 @@
+interface ConfigMap {
+  enableHotModuleReload: boolean;
+}
+type ConfigKeys = keyof ConfigMap;
+
+function createGlobalConfig() {
+  const config: ConfigMap = {
+    enableHotModuleReload: true,
+  };
+
+  return {
+    setProperty: <Key extends ConfigKeys>(key: Key, value: ConfigMap[Key]) => {
+      config[key] = value;
+    },
+    getProperty: <Key extends ConfigKeys>(key: Key) => {
+      return config[key];
+    },
+  };
+}
+
+export const rxBeachConfig = createGlobalConfig();

--- a/src/stateStreamRegistry.ts
+++ b/src/stateStreamRegistry.ts
@@ -28,6 +28,22 @@ export class StateStreamRegistry {
   }
 
   /**
+   * Unregister a stream from the registry
+   * 
+   * @param name The name of the stream
+   * @returns void
+   */
+  unregister(name: string) {
+    var stream = this.streams.get(name)
+    if (!stream) {
+        return;
+    }
+
+    this.streams.delete(name)
+    stream.unsubscribe();
+};
+
+  /**
    * Start the registered reduced state streams.
    *
    * This causes the streams to actually start reducing over the action stream.


### PR DESCRIPTION
Adds:
- a global config object in order to configure the internals of rxbeach
- enables opt-in HMR of persistentReducedStreams

What it does NOT handle:
- HMR of `reduceState()` and `action$.pipe()`s

I'm hoping we can use this to start a discussion about how we can enable full HMR support over time, the challenge is mainly accessing the internal state of observables in order to set the initial state based on the previous state like this PR does with persistentReducedStreams. 

Without being well versed in RXJS, I think the pattern of directly subscribing to the $action stream is problematic because it exposes implementation details to the end user, and prevents us from wrapping the registration to add things like HMR. To get where we want we need to be able to:
1. Access a $action stream observable's internal state
	- eg. in development, tap into the stream and store its local state where the re-registration can access it
2. Unregister an the observable from the $action stream
	- `.pipe` seems to remove this flexibility from us/requires that the developer register HMR manually
	- Perhaps we abstract the `action$.pipe` subscription in order to combine the `action$` stream with a development-mode `takeUntil(onDestroy$)`
3. Re-register the observable with the new implementation and previous state
	- The biggest question here is where do we get the previous state from, but there are many ways of doing this

I think it should be possible, my biggest problem at the moment is that I do not know RXJS well enough.

Not sure who else should review, but please add anyone who could have insight into this as I'm actively looking for feedback.