### PR TITLE
Properly type `useStream` when `defaultValue` provided

### DIFF
--- a/src/react/connect.ts
+++ b/src/react/connect.ts
@@ -5,6 +5,11 @@ export const NOT_YET_EMITTED = Symbol('Returned from rxbeach/react:useStream');
 // eslint-disable-next-line no-redeclare
 export type NOT_YET_EMITTED = typeof NOT_YET_EMITTED;
 
+type UseStream = {
+  <T>(source$: ObservableInput<T>, defaultValue: T): T;
+  <T>(source$: ObservableInput<T>, defaultValue?: T): T | NOT_YET_EMITTED;
+};
+
 /**
  * React hook to subscribe to a stream
  *
@@ -16,7 +21,7 @@ export type NOT_YET_EMITTED = typeof NOT_YET_EMITTED;
  * @param source$ Stream that provides the needed values
  * @param defaultValue Default value returned on init until stream emits new value
  */
-export const useStream = <T>(
+export const useStream: UseStream = <T>(
   source$: ObservableInput<T>,
   defaultValue?: T
 ): T | NOT_YET_EMITTED => {


### PR DESCRIPTION
It currently shows the value of `useStream` as `T | NOT_YET_EMITTED` even when `defaultValue` is provided, which is wrong -- if `defaultValue` is provided, the return type will always be `T`.

Typing works as expected: 

**Without default value**
![Screenshot 2023-01-18 at 15 56 29](https://user-images.githubusercontent.com/2342714/213323558-8dd5868f-6576-49f9-a2b4-a5ee83d3e337.png)

**With default value**
![Screenshot 2023-01-18 at 15 57 37](https://user-images.githubusercontent.com/2342714/213323658-18dc7d45-d614-4db9-8664-447dfa9c2415.png)


I've never worked on this repo before so I may need some help deploying, if this makes sense to you guys.